### PR TITLE
Fix jooq config to run with mvn spring-boot:run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.23</version>
         </dependency>
 
         <dependency>
@@ -201,12 +200,17 @@
                             <excludes/>
                             <inputSchema>public</inputSchema>
                         </database>
-
                         <target>
                             <packageName>com.test.db.jooq</packageName>
                             <directory>generated/jooq</directory>
                         </target>
                     </generator>
+                    <jdbc>
+                        <driver>org.postgresql.Driver</driver>
+                        <url>jdbc:postgresql://localhost:5433/myDB</url>
+                        <user>postgres</user>
+                        <password>test123</password>
+                    </jdbc>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
**Flyway logs:**

2020-10-08 11:34:32.196 DEBUG 9644 --- [ main] org.flywaydb.core.Flyway : DDL Transactions Supported: true
2020-10-08 11:34:32.196 DEBUG 9644 --- [ main] org.flywaydb.core.Flyway : Schemas:
2020-10-08 11:34:32.196 DEBUG 9644 --- [ main] org.flywaydb.core.Flyway : Default schema: null
2020-10-08 11:34:32.203 DEBUG 9644 --- [ main] o.f.c.i.c.SqlScriptCallbackFactory : Scanning for SQL callbacks ...
2020-10-08 11:34:32.211 DEBUG 9644 --- [ main] o.f.core.internal.command.DbValidate : Validating migrations ...
2020-10-08 11:34:32.213 DEBUG 9644 --- [ main] org.postgresql.jdbc.PgConnection : setAutoCommit = false
2020-10-08 11:34:32.225 DEBUG 9644 --- [ main] o.f.core.internal.scanner.Scanner : Filtering out resource: db/migration/V1_1_0__Init.sql (filename: V1_1_0__Init.sql)
2020-10-08 11:34:32.238 DEBUG 9644 --- [ main] org.postgresql.jdbc.PgConnection : setAutoCommit = true
2020-10-08 11:34:32.238 INFO 9644 --- [ main] o.f.core.internal.command.DbValidate : Successfully validated 1 migration (execution time 00:00.026s)
2020-10-08 11:34:32.244 INFO 9644 --- [ main] o.f.core.internal.command.DbMigrate : Current version of schema "public": 1.1.0
2020-10-08 11:34:32.245 INFO 9644 --- [ main] o.f.core.internal.command.DbMigrate : Schema "public" is up to date. No migration necessary.
2020-10-08 11:34:32.247 DEBUG 9644 --- [ main] org.postgresql.jdbc.PgConnection : setAutoCommit = false
2020-10-08 11:34:32.248 DEBUG 9644 --- [ main] org.postgresql.jdbc.PgConnection : setAutoCommit = true
2020-10-08 11:34:32.255 DEBUG 9644 --- [ main] org.flywaydb.core.Flyway : Memory usage: 20 of 504M

**Complete logs:**

$ **mvn spring-boot:run**
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------< org.example:backend_ >------------------------
[INFO] Building backend_ 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] >>> spring-boot-maven-plugin:2.3.4.RELEASE:run (default-cli) > test-compile @ backend_ >>>
[INFO]
[INFO] --- jooq-codegen-maven:3.13.4:generate (default) @ backend_ ---
[INFO] No <inputCatalog/> was provided. Generating ALL available catalogs instead.
[INFO] License parameters
[INFO] ----------------------------------------------------------
[INFO]   Thank you for using jOOQ and jOOQ's code generator
[INFO]
[INFO] Database parameters
[INFO] ----------------------------------------------------------
[INFO]   dialect                : POSTGRES
[INFO]   URL                    : jdbc:postgresql://localhost:5432/myDB
[INFO]   target dir             : D:\dev\projets\github\BrokenSpringBoot-1\generated\jooq
[INFO]   target package         : com.test.db.jooq
[INFO]   includes               : [.*]
[INFO]   excludes               : []
[INFO]   includeExcludeColumns  : false
[INFO] ----------------------------------------------------------
[INFO]
[INFO] JavaGenerator parameters
[INFO] ----------------------------------------------------------
[INFO]   annotations (generated): false
[INFO]   annotations (JPA: any) : false
[INFO]   annotations (JPA: version):
[INFO]   annotations (validation): false
[INFO]   comments               : true
[INFO]   comments on attributes : true
[INFO]   comments on catalogs   : true
[INFO]   comments on columns    : true
[INFO]   comments on keys       : true
[INFO]   comments on links      : true
[INFO]   comments on packages   : true
[INFO]   comments on parameters : true
[INFO]   comments on queues     : true
[INFO]   comments on routines   : true
[INFO]   comments on schemas    : true
[INFO]   comments on sequences  : true
[INFO]   comments on tables     : true
[INFO]   comments on udts       : true
[INFO]   sources                : true
[INFO]   sources on views       : true
[INFO]   daos                   : false
[INFO]   deprecated code        : true
[INFO]   global references (any): true
[INFO]   global references (catalogs): true
[INFO]   global references (keys): true
[INFO]   global references (links): true
[INFO]   global references (queues): true
[INFO]   global references (routines): true
[INFO]   global references (schemas): true
[INFO]   global references (sequences): true
[INFO]   global references (tables): true
[INFO]   global references (udts): true
[INFO]   indexes                : true
[INFO]   instance fields        : true
[INFO]   interfaces             : false
[INFO]   interfaces (immutable) : false
[INFO]   javadoc                : true
[INFO]   keys                   : true
[INFO]   links                  : true
[INFO]   pojos                  : false
[INFO]   pojos (immutable)      : false
[INFO]   queues                 : true
[INFO]   records                : true
[INFO]   routines               : true
[INFO]   sequences              : true
[INFO]   sequenceFlags          : true
[INFO]   table-valued functions : true
[INFO]   tables                 : true
[INFO]   udts                   : true
[INFO]   relations              : true
[INFO] ----------------------------------------------------------
[INFO]
[INFO] Generation remarks
[INFO] ----------------------------------------------------------
[INFO]
[INFO] ----------------------------------------------------------
[INFO] Generating catalogs      : Total: 1
[INFO]

@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@  @@        @@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@        @@@@@@@@@@
@@@@@@@@@@@@@@@@  @@  @@    @@@@@@@@@@
@@@@@@@@@@  @@@@  @@  @@    @@@@@@@@@@
@@@@@@@@@@        @@        @@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@        @@        @@@@@@@@@@
@@@@@@@@@@    @@  @@  @@@@  @@@@@@@@@@
@@@@@@@@@@    @@  @@  @@@@  @@@@@@@@@@
@@@@@@@@@@        @@  @  @  @@@@@@@@@@
@@@@@@@@@@        @@        @@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@  @@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@  Thank you for using jOOQ 3.13.4

[INFO] ARRAYs fetched           : 0 (0 included, 0 excluded)
[INFO] Enums fetched            : 0 (0 included, 0 excluded)
[INFO] Packages fetched         : 0 (0 included, 0 excluded)
[INFO] Routines fetched         : 0 (0 included, 0 excluded)
[INFO] Sequences fetched        : 0 (0 included, 0 excluded)
[INFO] Tables fetched           : 2 (2 included, 0 excluded)
[INFO] No schema version is applied for catalog . Regenerating.
[INFO]
[INFO] Generating catalog       : DefaultCatalog.java
[INFO] ==========================================================
[INFO] Generating schemata      : Total: 1
[INFO] No schema version is applied for schema public. Regenerating.
[INFO] Generating schema        : Public.java
[INFO] ----------------------------------------------------------
[INFO] UDTs fetched             : 0 (0 included, 0 excluded)
[INFO] Generating tables
[INFO] Synthetic primary keys   : 0 (0 included, 0 excluded)
[INFO] Overriding primary keys  : 2 (0 included, 2 excluded)
[INFO] Generating table         : FlywaySchemaHistory.java [input=flyway_schema_history, output=flyway_schema_history, pk=flyway_schema_history_pk]
[INFO] Embeddables fetched      : 0 (0 included, 0 excluded)
[INFO] Indexes fetched          : 1 (1 included, 0 excluded)
[INFO] Generating table         : Test.java [input=test, output=test, pk=test_pkey]
[INFO] Tables generated         : Total: 1.565s
[INFO] Generating table references
[INFO] Table refs generated     : Total: 1.574s, +8.48ms
[INFO] Generating Keys
[INFO] Keys generated           : Total: 1.583s, +8.69ms
[INFO] Generating Indexes
[INFO] Indexes generated        : Total: 1.59s, +7.692ms
[INFO] Generating table records
[INFO] Generating record        : FlywaySchemaHistoryRecord.java
[INFO] Generating record        : TestRecord.java
[INFO] Table records generated  : Total: 1.633s, +42.99ms
[INFO] Domains fetched          : 0 (0 included, 0 excluded)
[INFO] Generation finished: public: Total: 1.668s, +34.565ms
[INFO]
[INFO] Removing excess files
[INFO]
[INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ backend_ ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] Copying 1 resource
[INFO]
[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ backend_ ---
[INFO] Nothing to compile - all classes are up to date
[INFO]
[INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ backend_ ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory D:\dev\projets\github\BrokenSpringBoot-1\src\test\resources
[INFO]
[INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ backend_ ---
[INFO] No sources to compile
[INFO]
[INFO] <<< spring-boot-maven-plugin:2.3.4.RELEASE:run (default-cli) < test-compile @ backend_ <<<
[INFO]
[INFO]
[INFO] --- spring-boot-maven-plugin:2.3.4.RELEASE:run (default-cli) @ backend_ ---
[INFO] Attaching agents: []
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/D:/DONNEES/maven-local-repo/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/D:/DONNEES/maven-local-repo/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
2020-10-08 11:34:28.200 DEBUG 9644 --- [           main] .c.l.ClasspathLoggingApplicationListener : Application started with classpath: unknown

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::        (v2.3.4.RELEASE)

2020-10-08 11:34:28.291  INFO 9644 --- [           main] com.test.SpringMain                      : Starting SpringMain on FR07122802L with PID 9644 (D:\dev\projets\github\BrokenSpringBoot-1\target\classes star
ted by X168845 in D:\dev\projets\github\BrokenSpringBoot-1)
2020-10-08 11:34:28.292 DEBUG 9644 --- [           main] com.test.SpringMain                      : Running with Spring Boot v2.3.4.RELEASE, Spring v5.2.9.RELEASE
2020-10-08 11:34:28.292  INFO 9644 --- [           main] com.test.SpringMain                      : No active profile set, falling back to default profiles: default
2020-10-08 11:34:28.293 DEBUG 9644 --- [           main] o.s.boot.SpringApplication               : Loading source class com.test.SpringMain
2020-10-08 11:34:28.338 DEBUG 9644 --- [           main] o.s.b.c.c.ConfigFileApplicationListener  : Loaded config file 'file:/D:/dev/projets/github/BrokenSpringBoot-1/target/classes/application.yml' (classpath:
/application.yml)
2020-10-08 11:34:28.339 DEBUG 9644 --- [           main] ConfigServletWebServerApplicationContext : Refreshing org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676
cf48
2020-10-08 11:34:28.360 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.context.annotation.internalConfigurationAnnota
tionProcessor'
2020-10-08 11:34:28.370 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.internalCachingMetadataRead
erFactory'
2020-10-08 11:34:28.639 DEBUG 9644 --- [           main] o.s.c.e.PropertySourcesPropertyResolver  : Found key 'spring.datasource.url' in PropertySource 'configurationProperties' with value of type String
2020-10-08 11:34:28.691 DEBUG 9644 --- [           main] o.s.c.e.PropertySourcesPropertyResolver  : Found key 'spring.flyway.enabled' in PropertySource 'configurationProperties' with value of type Boolean
2020-10-08 11:34:28.849  INFO 9644 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JDBC repositories in DEFAULT mode.
2020-10-08 11:34:28.852 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.AutoConfigurationPackages'
2020-10-08 11:34:28.859 DEBUG 9644 --- [           main] o.s.b.a.AutoConfigurationPackages        : @EnableAutoConfiguration was declared on a class in the package 'com.test'. Automatic @Repository and @Entity
scanning is enabled.
2020-10-08 11:34:28.861 DEBUG 9644 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Scanning for JDBC repositories in packages com.test.
2020-10-08 11:34:28.879  INFO 9644 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 17ms. Found 0 JDBC repository interfaces.
2020-10-08 11:34:28.903 DEBUG 9644 --- [           main] o.s.c.e.PropertySourcesPropertyResolver  : Found key 'spring.flyway.enabled' in PropertySource 'configurationProperties' with value of type Boolean
2020-10-08 11:34:29.027 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'propertySourcesPlaceholderConfigurer'
2020-10-08 11:34:29.030 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.flyway.FlywayAutoConfigurat
ion$FlywayMigrationInitializerJdbcOperationsDependsOnPostProcessor'
2020-10-08 11:34:29.037 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.flyway.FlywayAutoConfigurat
ion$FlywayMigrationInitializerNamedParameterJdbcOperationsDependsOnPostProcessor'
2020-10-08 11:34:29.042 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.flyway.FlywayAutoConfigurat
ion$FlywayJdbcOperationsDependsOnPostProcessor'
2020-10-08 11:34:29.043 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.flyway.FlywayAutoConfigurat
ion$FlywayNamedParameterJdbcOperationsDependencyConfiguration'
2020-10-08 11:34:29.045 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.context.event.internalEventListenerProcessor'
2020-10-08 11:34:29.046 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'preserveErrorControllerTargetClassPostProcessor'
2020-10-08 11:34:29.046 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.context.event.internalEventListenerFactory'
2020-10-08 11:34:29.047 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.transaction.config.internalTransactionalEventL
istenerFactory'
2020-10-08 11:34:29.050 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.context.annotation.internalAutowiredAnnotation
Processor'
2020-10-08 11:34:29.051 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.context.annotation.internalCommonAnnotationPro
cessor'
2020-10-08 11:34:29.054 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.context.properties.ConfigurationPropertie
sBindingPostProcessor'
2020-10-08 11:34:29.054 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.context.internalConfigurationPropertiesBi
nder'
2020-10-08 11:34:29.055 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.context.internalConfigurationPropertiesBi
nderFactory'
2020-10-08 11:34:29.057 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.context.annotation.internalScheduledAnnotation
Processor'
2020-10-08 11:34:29.057 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.scheduling.annotation.SchedulingConfiguration'

2020-10-08 11:34:29.071 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'dataSourceInitializerPostProcessor'
2020-10-08 11:34:29.075 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'persistenceExceptionTranslationPostProcessor'
2020-10-08 11:34:29.078 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'persistenceExceptionTranslationPostProcessor' via factory method to bean na
med 'environment'
2020-10-08 11:34:29.086 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.aop.config.internalAutoProxyCreator'
2020-10-08 11:34:29.113 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'webServerFactoryCustomizerBeanPostProcessor'
2020-10-08 11:34:29.114 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'errorPageRegistrarBeanPostProcessor'
2020-10-08 11:34:29.114 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'projectingArgumentResolverBeanPostProcessor'
2020-10-08 11:34:29.123 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.transaction.config.internalTransactionAdvisor'

2020-10-08 11:34:29.124 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.transaction.annotation.ProxyTransactionManagem
entConfiguration'
2020-10-08 11:34:29.151 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'transactionAttributeSource'
2020-10-08 11:34:29.157 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'transactionInterceptor'
2020-10-08 11:34:29.158 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'transactionInterceptor' via factory method to bean named 'transactionAttrib
uteSource'
2020-10-08 11:34:29.178 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.transaction.config.internalTransactionAdvisor' via fact
ory method to bean named 'transactionAttributeSource'
2020-10-08 11:34:29.179 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.transaction.config.internalTransactionAdvisor' via fact
ory method to bean named 'transactionInterceptor'
2020-10-08 11:34:29.189 DEBUG 9644 --- [           main] o.s.u.c.s.UiApplicationContextUtils      : Unable to locate ThemeSource with name 'themeSource': using default [org.springframework.ui.context.support.Re
sourceBundleThemeSource@128c502c]
2020-10-08 11:34:29.192 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'tomcatServletWebServerFactory'
2020-10-08 11:34:29.196 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.ServletWebServe
rFactoryConfiguration$EmbeddedTomcat'
2020-10-08 11:34:29.246 DEBUG 9644 --- [           main] o.a.catalina.core.AprLifecycleListener   : The Apache Tomcat Native library could not be found using names [tcnative-1, libtcnative-1] on the java.librar
y.path [D:\dev\tools\jdk-11.0.2\bin;C:\WINDOWS\Sun\Java\bin;C:\WINDOWS\system32;C:\WINDOWS;D:\Program Files\Git\mingw64\bin;D:\Program Files\Git\usr\bin;P:\bin;C:\ProgramData\DockerDesktop\version-bin;C:\Progra
m Files\Docker\Docker\Resources\bin;D:\dev\tools\jdk-11.0.2\bin;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0;C:\Program Files\Axalto\Access Client\v5;C:\Pro
gram Files (x86)\Gemalto\Access Client\v5;C:\Program Files (x86)\Cisco\WebEx Productivity Tools\2.40.17006.10006;D:\dev\tools\apache-maven-3.6.0\bin;C:\Program Files (x86)\Yarn\bin;D:\Program Files\Git\cmd;C:\P
rogram Files\MongoDB\Server\4.0\bin;D:\Program Files\nodejs;C:\WINDOWS\System32\OpenSSH;C:\Users\X168845\AppData\Local\Microsoft\WindowsApps;C:\Users\X168845\AppData\Local\GitHubDesktop\bin;C:\Users\X168845\App
Data\Roaming\npm;C:\Users\X168845\AppData\Local\Microsoft\WindowsApps;C:\Users\X168845\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\X168845\AppData\Local\Programs\Fiddler;C:\Users\X168845\Documents\Win
dowsPowerShell\Scripts;.]. The errors reported were [Can't load library: D:\dev\projets\github\BrokenSpringBoot-1\bin\tcnative-1.dll, Can't load library: D:\dev\projets\github\BrokenSpringBoot-1\bin\libtcnative
-1.dll, no tcnative-1 in java.library.path: [D:\dev\tools\jdk-11.0.2\bin, C:\WINDOWS\Sun\Java\bin, C:\WINDOWS\system32, C:\WINDOWS, D:\Program Files\Git\mingw64\bin, D:\Program Files\Git\usr\bin, P:\bin, C:\Pro
gramData\DockerDesktop\version-bin, C:\Program Files\Docker\Docker\Resources\bin, D:\dev\tools\jdk-11.0.2\bin, C:\WINDOWS\system32, C:\WINDOWS, C:\WINDOWS\System32\Wbem, C:\WINDOWS\System32\WindowsPowerShell\v1
.0, C:\Program Files\Axalto\Access Client\v5, C:\Program Files (x86)\Gemalto\Access Client\v5, C:\Program Files (x86)\Cisco\WebEx Productivity Tools\2.40.17006.10006, D:\dev\tools\apache-maven-3.6.0\bin, C:\Pro
gram Files (x86)\Yarn\bin, D:\Program Files\Git\cmd, C:\Program Files\MongoDB\Server\4.0\bin, D:\Program Files\nodejs, C:\WINDOWS\System32\OpenSSH, C:\Users\X168845\AppData\Local\Microsoft\WindowsApps, C:\Users
\X168845\AppData\Local\GitHubDesktop\bin, C:\Users\X168845\AppData\Roaming\npm, C:\Users\X168845\AppData\Local\Microsoft\WindowsApps, C:\Users\X168845\AppData\Local\Programs\Microsoft VS Code\bin, C:\Users\X168
845\AppData\Local\Programs\Fiddler, C:\Users\X168845\Documents\WindowsPowerShell\Scripts, .], no libtcnative-1 in java.library.path: [D:\dev\tools\jdk-11.0.2\bin, C:\WINDOWS\Sun\Java\bin, C:\WINDOWS\system32, C
:\WINDOWS, D:\Program Files\Git\mingw64\bin, D:\Program Files\Git\usr\bin, P:\bin, C:\ProgramData\DockerDesktop\version-bin, C:\Program Files\Docker\Docker\Resources\bin, D:\dev\tools\jdk-11.0.2\bin, C:\WINDOWS
\system32, C:\WINDOWS, C:\WINDOWS\System32\Wbem, C:\WINDOWS\System32\WindowsPowerShell\v1.0, C:\Program Files\Axalto\Access Client\v5, C:\Program Files (x86)\Gemalto\Access Client\v5, C:\Program Files (x86)\Cis
co\WebEx Productivity Tools\2.40.17006.10006, D:\dev\tools\apache-maven-3.6.0\bin, C:\Program Files (x86)\Yarn\bin, D:\Program Files\Git\cmd, C:\Program Files\MongoDB\Server\4.0\bin, D:\Program Files\nodejs, C:
\WINDOWS\System32\OpenSSH, C:\Users\X168845\AppData\Local\Microsoft\WindowsApps, C:\Users\X168845\AppData\Local\GitHubDesktop\bin, C:\Users\X168845\AppData\Roaming\npm, C:\Users\X168845\AppData\Local\Microsoft\
WindowsApps, C:\Users\X168845\AppData\Local\Programs\Microsoft VS Code\bin, C:\Users\X168845\AppData\Local\Programs\Fiddler, C:\Users\X168845\Documents\WindowsPowerShell\Scripts, .]]

org.apache.tomcat.jni.LibraryNotFoundError: Can't load library: D:\dev\projets\github\BrokenSpringBoot-1\bin\tcnative-1.dll, Can't load library: D:\dev\projets\github\BrokenSpringBoot-1\bin\libtcnative-1.dll, n
o tcnative-1 in java.library.path: [D:\dev\tools\jdk-11.0.2\bin, C:\WINDOWS\Sun\Java\bin, C:\WINDOWS\system32, C:\WINDOWS, D:\Program Files\Git\mingw64\bin, D:\Program Files\Git\usr\bin, P:\bin, C:\ProgramData\
DockerDesktop\version-bin, C:\Program Files\Docker\Docker\Resources\bin, D:\dev\tools\jdk-11.0.2\bin, C:\WINDOWS\system32, C:\WINDOWS, C:\WINDOWS\System32\Wbem, C:\WINDOWS\System32\WindowsPowerShell\v1.0, C:\Pr
ogram Files\Axalto\Access Client\v5, C:\Program Files (x86)\Gemalto\Access Client\v5, C:\Program Files (x86)\Cisco\WebEx Productivity Tools\2.40.17006.10006, D:\dev\tools\apache-maven-3.6.0\bin, C:\Program File
s (x86)\Yarn\bin, D:\Program Files\Git\cmd, C:\Program Files\MongoDB\Server\4.0\bin, D:\Program Files\nodejs, C:\WINDOWS\System32\OpenSSH, C:\Users\X168845\AppData\Local\Microsoft\WindowsApps, C:\Users\X168845\
AppData\Local\GitHubDesktop\bin, C:\Users\X168845\AppData\Roaming\npm, C:\Users\X168845\AppData\Local\Microsoft\WindowsApps, C:\Users\X168845\AppData\Local\Programs\Microsoft VS Code\bin, C:\Users\X168845\AppDa
ta\Local\Programs\Fiddler, C:\Users\X168845\Documents\WindowsPowerShell\Scripts, .], no libtcnative-1 in java.library.path: [D:\dev\tools\jdk-11.0.2\bin, C:\WINDOWS\Sun\Java\bin, C:\WINDOWS\system32, C:\WINDOWS
, D:\Program Files\Git\mingw64\bin, D:\Program Files\Git\usr\bin, P:\bin, C:\ProgramData\DockerDesktop\version-bin, C:\Program Files\Docker\Docker\Resources\bin, D:\dev\tools\jdk-11.0.2\bin, C:\WINDOWS\system32
, C:\WINDOWS, C:\WINDOWS\System32\Wbem, C:\WINDOWS\System32\WindowsPowerShell\v1.0, C:\Program Files\Axalto\Access Client\v5, C:\Program Files (x86)\Gemalto\Access Client\v5, C:\Program Files (x86)\Cisco\WebEx
Productivity Tools\2.40.17006.10006, D:\dev\tools\apache-maven-3.6.0\bin, C:\Program Files (x86)\Yarn\bin, D:\Program Files\Git\cmd, C:\Program Files\MongoDB\Server\4.0\bin, D:\Program Files\nodejs, C:\WINDOWS\
System32\OpenSSH, C:\Users\X168845\AppData\Local\Microsoft\WindowsApps, C:\Users\X168845\AppData\Local\GitHubDesktop\bin, C:\Users\X168845\AppData\Roaming\npm, C:\Users\X168845\AppData\Local\Microsoft\WindowsAp
ps, C:\Users\X168845\AppData\Local\Programs\Microsoft VS Code\bin, C:\Users\X168845\AppData\Local\Programs\Fiddler, C:\Users\X168845\Documents\WindowsPowerShell\Scripts, .]
        at org.apache.tomcat.jni.Library.<init>(Library.java:102) ~[tomcat-embed-core-9.0.38.jar:9.0.38]
        at org.apache.tomcat.jni.Library.initialize(Library.java:206) ~[tomcat-embed-core-9.0.38.jar:9.0.38]
        at org.apache.catalina.core.AprLifecycleListener.init(AprLifecycleListener.java:193) ~[tomcat-embed-core-9.0.38.jar:9.0.38]
        at org.apache.catalina.core.AprLifecycleListener.isAprAvailable(AprLifecycleListener.java:102) ~[tomcat-embed-core-9.0.38.jar:9.0.38]
        at org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory.getDefaultLifecycleListeners(TomcatServletWebServerFactory.java:168) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory.<init>(TomcatServletWebServerFactory.java:119) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryConfiguration$EmbeddedTomcat.tomcatServletWebServerFactory(ServletWebServerFactoryConfiguration.java:75) ~[spring-boot-autoco
nfigure-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
        at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:154) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:650) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:635) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1336) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE
]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1176) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:556) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:516) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:324) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:322) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:207) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.getWebServerFactory(ServletWebServerApplicationContext.java:212) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.createWebServer(ServletWebServerApplicationContext.java:177) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.onRefresh(ServletWebServerApplicationContext.java:158) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:545) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:143) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:758) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:750) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:315) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1237) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1226) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at com.test.SpringMain.main(SpringMain.java:20) ~[classes/:na]

2020-10-08 11:34:29.265 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'websocketServletWebServerCustomizer'
2020-10-08 11:34:29.265 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.websocket.servlet.WebSocket
ServletAutoConfiguration$TomcatWebSocketConfiguration'
2020-10-08 11:34:29.267 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'servletWebServerFactoryCustomizer'
2020-10-08 11:34:29.276 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.ServletWebServe
rFactoryAutoConfiguration'
2020-10-08 11:34:29.280 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'server-org.springframework.boot.autoconfigure.web.ServerProperties
'
2020-10-08 11:34:29.285 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.context.properties.BoundConfigurationProp
erties'
2020-10-08 11:34:29.290 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'stringOrNumberMigrationVersionConverter'
2020-10-08 11:34:29.291 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.flyway.FlywayAutoConfigurat
ion'
2020-10-08 11:34:29.299 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'servletWebServerFactoryCustomizer' via factory method to bean named 'server
-org.springframework.boot.autoconfigure.web.ServerProperties'
2020-10-08 11:34:29.299 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'tomcatServletWebServerFactoryCustomizer'
2020-10-08 11:34:29.300 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'tomcatServletWebServerFactoryCustomizer' via factory method to bean named '
server-org.springframework.boot.autoconfigure.web.ServerProperties'
2020-10-08 11:34:29.301 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'tomcatWebServerFactoryCustomizer'
2020-10-08 11:34:29.301 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebSer
verFactoryCustomizerAutoConfiguration$TomcatWebServerFactoryCustomizerConfiguration'
2020-10-08 11:34:29.302 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'tomcatWebServerFactoryCustomizer' via factory method to bean named 'environ
ment'
2020-10-08 11:34:29.302 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'tomcatWebServerFactoryCustomizer' via factory method to bean named 'server-
org.springframework.boot.autoconfigure.web.ServerProperties'
2020-10-08 11:34:29.303 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'localeCharsetMappingsCustomizer'
2020-10-08 11:34:29.304 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAut
oConfiguration'
2020-10-08 11:34:29.304 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfigur
ation' via constructor to bean named 'server-org.springframework.boot.autoconfigure.web.ServerProperties'
2020-10-08 11:34:29.326 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'errorPageCustomizer'
2020-10-08 11:34:29.327 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcA
utoConfiguration'
2020-10-08 11:34:29.328 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfig
uration' via constructor to bean named 'server-org.springframework.boot.autoconfigure.web.ServerProperties'
2020-10-08 11:34:29.331 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'dispatcherServletRegistration'
2020-10-08 11:34:29.332 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.DispatcherServl
etAutoConfiguration$DispatcherServletRegistrationConfiguration'
2020-10-08 11:34:29.333 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'dispatcherServlet'
2020-10-08 11:34:29.333 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.DispatcherServl
etAutoConfiguration$DispatcherServletConfiguration'
2020-10-08 11:34:29.335 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.mvc-org.springframework.boot.autoconfigure.web.servlet.WebM
vcProperties'
2020-10-08 11:34:29.342 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dispatcherServlet' via factory method to bean named 'spring.mvc-org.springf
ramework.boot.autoconfigure.web.servlet.WebMvcProperties'
2020-10-08 11:34:29.357 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dispatcherServletRegistration' via factory method to bean named 'dispatcher
Servlet'
2020-10-08 11:34:29.357 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dispatcherServletRegistration' via factory method to bean named 'spring.mvc
-org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties'
2020-10-08 11:34:29.359 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'multipartConfigElement'
2020-10-08 11:34:29.359 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.MultipartAutoCo
nfiguration'
2020-10-08 11:34:29.360 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.servlet.multipart-org.springframework.boot.autoconfigure.we
b.servlet.MultipartProperties'
2020-10-08 11:34:29.363 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfigurati
on' via constructor to bean named 'spring.servlet.multipart-org.springframework.boot.autoconfigure.web.servlet.MultipartProperties'
2020-10-08 11:34:29.367 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'errorPageCustomizer' via factory method to bean named 'dispatcherServletReg
istration'
2020-10-08 11:34:30.261 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.apache.coyote.http11.Http11NioProtocol port=8080)
2020-10-08 11:34:30.267 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.apache.coyote.http11.Http11NioProtocol bindOnInit=false)
2020-10-08 11:34:30.268 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.apache.tomcat.util.net.NioEndpoint bindOnInit=false)
2020-10-08 11:34:30.270 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.apache.coyote.http11.Http11NioProtocol maxPostSize=2097152)
2020-10-08 11:34:30.271 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.apache.tomcat.util.net.NioEndpoint maxPostSize=2097152)
2020-10-08 11:34:30.282 DEBUG 9644 --- [           main] org.apache.catalina.core.ContainerBase   : Add child StandardHost[localhost] StandardEngine[Tomcat]
2020-10-08 11:34:30.283 DEBUG 9644 --- [           main] .s.b.w.e.t.TomcatServletWebServerFactory : Code archive: D:\DONNEES\maven-local-repo\org\springframework\boot\spring-boot\2.3.4.RELEASE\spring-boot-2.3.4
.RELEASE.jar
2020-10-08 11:34:30.283 DEBUG 9644 --- [           main] .s.b.w.e.t.TomcatServletWebServerFactory : Code archive: D:\DONNEES\maven-local-repo\org\springframework\boot\spring-boot\2.3.4.RELEASE\spring-boot-2.3.4
.RELEASE.jar
2020-10-08 11:34:30.283 DEBUG 9644 --- [           main] .s.b.w.e.t.TomcatServletWebServerFactory : None of the document roots [src/main/webapp, public, static] point to a directory and will be ignored.
2020-10-08 11:34:30.301 DEBUG 9644 --- [           main] org.apache.catalina.core.ContainerBase   : Add child StandardWrapper[default] TomcatEmbeddedContext[]
2020-10-08 11:34:30.303 DEBUG 9644 --- [           main] org.apache.catalina.core.ContainerBase   : Add child TomcatEmbeddedContext[] StandardEngine[Tomcat].StandardHost[localhost]
2020-10-08 11:34:30.305  INFO 9644 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8080 (http)
2020-10-08 11:34:30.315 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.apache.coyote.http11.Http11NioProtocol parseBodyMethods=POST)
2020-10-08 11:34:30.316 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.apache.tomcat.util.net.NioEndpoint parseBodyMethods=POST)
2020-10-08 11:34:30.316  INFO 9644 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2020-10-08 11:34:30.317  INFO 9644 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet engine: [Apache Tomcat/9.0.38]
2020-10-08 11:34:30.319 DEBUG 9644 --- [           main] o.apache.catalina.core.StandardContext   : Starting ROOT
2020-10-08 11:34:30.339 DEBUG 9644 --- [           main] o.apache.catalina.core.StandardContext   : Configuring default Resources
2020-10-08 11:34:30.554 DEBUG 9644 --- [           main] o.apache.catalina.core.StandardContext   : Processing standard container startup
2020-10-08 11:34:30.554 DEBUG 9644 --- [           main] org.apache.catalina.loader.WebappLoader  : Starting this Loader
2020-10-08 11:34:30.560 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLo
ader clearReferencesRmiTargets=false)
2020-10-08 11:34:30.561 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLo
ader clearReferencesStopThreads=false)
2020-10-08 11:34:30.562 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLo
ader clearReferencesStopTimerThreads=false)
2020-10-08 11:34:30.562 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLo
ader clearReferencesHttpClientKeepAliveThread=true)
2020-10-08 11:34:30.573 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLo
ader clearReferencesObjectStreamClassCaches=false)
2020-10-08 11:34:30.574 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLo
ader clearReferencesObjectStreamClassCaches=false)
2020-10-08 11:34:30.574 DEBUG 9644 --- [           main] o.apache.tomcat.util.IntrospectionUtils  : IntrospectionUtils: setProperty(class org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLo
ader clearReferencesThreadLocals=false)
2020-10-08 11:34:30.614 DEBUG 9644 --- [           main] o.a.c.authenticator.AuthenticatorBase    : No SingleSignOn Valve is present
2020-10-08 11:34:30.615 DEBUG 9644 --- [           main] o.apache.catalina.core.StandardContext   : No manager found. Checking if cluster manager should be used. Cluster configured: [false], Application distrib
utable: [false]
2020-10-08 11:34:30.618 DEBUG 9644 --- [           main] o.apache.catalina.core.StandardContext   : Configured a manager of class [org.apache.catalina.session.StandardManager]
2020-10-08 11:34:30.625  INFO 9644 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2020-10-08 11:34:30.625 DEBUG 9644 --- [           main] w.s.c.ServletWebServerApplicationContext : Published root WebApplicationContext as ServletContext attribute with name [org.springframework.web.context.We
bApplicationContext.ROOT]
2020-10-08 11:34:30.625  INFO 9644 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 2286 ms
2020-10-08 11:34:30.628 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'requestContextFilter'
2020-10-08 11:34:30.631 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'formContentFilter'
2020-10-08 11:34:30.632 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfi
guration'
2020-10-08 11:34:30.635 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'characterEncodingFilter'
2020-10-08 11:34:30.642 DEBUG 9644 --- [           main] o.s.b.w.s.ServletContextInitializerBeans : Mapping filters: characterEncodingFilter urls=[/*] order=-2147483648, formContentFilter urls=[/*] order=-9900,
 requestContextFilter urls=[/*] order=-105
2020-10-08 11:34:30.647 DEBUG 9644 --- [           main] o.s.b.w.s.ServletContextInitializerBeans : Mapping servlets: dispatcherServlet urls=[/]
2020-10-08 11:34:30.648 DEBUG 9644 --- [           main] org.apache.catalina.core.ContainerBase   : Add child StandardWrapper[dispatcherServlet] StandardEngine[Tomcat].StandardHost[localhost].TomcatEmbeddedCont
ext[]
2020-10-08 11:34:30.652 DEBUG 9644 --- [           main] o.apache.catalina.core.StandardContext   : Configuring application event listeners
2020-10-08 11:34:30.653 DEBUG 9644 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       :  Configuring event listener class 'org.apache.tomcat.websocket.server.WsContextListener'
2020-10-08 11:34:30.654 DEBUG 9644 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Sending application start events
2020-10-08 11:34:30.662 DEBUG 9644 --- [           main] o.a.catalina.session.StandardManager     : Start: Loading persisted sessions
2020-10-08 11:34:30.663 DEBUG 9644 --- [           main] o.a.catalina.session.StandardManager     : Loading persisted sessions from [SESSIONS.ser]
2020-10-08 11:34:30.666 DEBUG 9644 --- [           main] o.a.catalina.session.StandardManager     : No persisted data file found
2020-10-08 11:34:30.667 DEBUG 9644 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Starting filters
2020-10-08 11:34:30.668 DEBUG 9644 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       :  Starting filter 'requestContextFilter'
2020-10-08 11:34:30.670 DEBUG 9644 --- [           main] o.s.b.w.s.f.OrderedRequestContextFilter  : Filter 'requestContextFilter' configured for use
2020-10-08 11:34:30.671 DEBUG 9644 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       :  Starting filter 'Tomcat WebSocket (JSR356) Filter'
2020-10-08 11:34:30.672 DEBUG 9644 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       :  Starting filter 'characterEncodingFilter'
2020-10-08 11:34:30.672 DEBUG 9644 --- [           main] s.b.w.s.f.OrderedCharacterEncodingFilter : Filter 'characterEncodingFilter' configured for use
2020-10-08 11:34:30.673 DEBUG 9644 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       :  Starting filter 'formContentFilter'
2020-10-08 11:34:30.674 DEBUG 9644 --- [           main] o.s.b.w.s.f.OrderedFormContentFilter     : Filter 'formContentFilter' configured for use
2020-10-08 11:34:30.674 DEBUG 9644 --- [           main] o.apache.catalina.core.StandardContext   : Starting completed
2020-10-08 11:34:30.677 DEBUG 9644 --- [           main] org.apache.catalina.mapper.Mapper        : Registered host [localhost]
2020-10-08 11:34:30.685 DEBUG 9644 --- [           main] o.apache.catalina.mapper.MapperListener  : Register Wrapper [default] in Context [] for service [StandardService[Tomcat]]
2020-10-08 11:34:30.686 DEBUG 9644 --- [           main] o.apache.catalina.mapper.MapperListener  : Register Wrapper [dispatcherServlet] in Context [] for service [StandardService[Tomcat]]
2020-10-08 11:34:30.688 DEBUG 9644 --- [           main] o.apache.catalina.mapper.MapperListener  : Register Context [] for service [StandardService[Tomcat]]
2020-10-08 11:34:30.688 DEBUG 9644 --- [           main] o.apache.catalina.mapper.MapperListener  : Register host [localhost] at domain [null] for service [StandardService[Tomcat]]
2020-10-08 11:34:30.693 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'springMain'
2020-10-08 11:34:30.694 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.context.PropertyPlaceholder
AutoConfiguration'
2020-10-08 11:34:30.695 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.websocket.servlet.WebSocket
ServletAutoConfiguration'
2020-10-08 11:34:30.696 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.context.properties.ConfigurationBeanFacto
ryMetadata'
2020-10-08 11:34:30.696 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.DispatcherServl
etAutoConfiguration'
2020-10-08 11:34:30.697 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfi
guration'
2020-10-08 11:34:30.698 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'taskExecutorBuilder'
2020-10-08 11:34:30.699 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.task.execution-org.springframework.boot.autoconfigure.task.
TaskExecutionProperties'
2020-10-08 11:34:30.701 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'taskExecutorBuilder' via factory method to bean named 'spring.task.executio
n-org.springframework.boot.autoconfigure.task.TaskExecutionProperties'
2020-10-08 11:34:30.704 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcA
utoConfiguration$WhitelabelErrorViewConfiguration'
2020-10-08 11:34:30.705 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'error'
2020-10-08 11:34:30.705 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'beanNameViewResolver'
2020-10-08 11:34:30.706 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcA
utoConfiguration$DefaultErrorViewResolverConfiguration'
2020-10-08 11:34:30.707 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.resources-org.springframework.boot.autoconfigure.web.Resour
ceProperties'
2020-10-08 11:34:30.710 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfig
uration$DefaultErrorViewResolverConfiguration' via constructor to bean named 'org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676cf48'
2020-10-08 11:34:30.710 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfig
uration$DefaultErrorViewResolverConfiguration' via constructor to bean named 'spring.resources-org.springframework.boot.autoconfigure.web.ResourceProperties'
2020-10-08 11:34:30.711 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'conventionErrorViewResolver'
2020-10-08 11:34:30.713 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'errorAttributes'
2020-10-08 11:34:30.714 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'basicErrorController'
2020-10-08 11:34:30.715 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'basicErrorController' via factory method to bean named 'errorAttributes'
2020-10-08 11:34:30.721 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfi
guration$EnableWebMvcConfiguration'
2020-10-08 11:34:30.724 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$
EnableWebMvcConfiguration' via constructor to bean named 'spring.resources-org.springframework.boot.autoconfigure.web.ResourceProperties'
2020-10-08 11:34:30.732 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$
EnableWebMvcConfiguration' via constructor to bean named 'org.springframework.beans.factory.support.DefaultListableBeanFactory@62e6b5c8'
2020-10-08 11:34:30.744 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfi
guration$WebMvcAutoConfigurationAdapter'
2020-10-08 11:34:30.745 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$
WebMvcAutoConfigurationAdapter' via constructor to bean named 'spring.resources-org.springframework.boot.autoconfigure.web.ResourceProperties'
2020-10-08 11:34:30.746 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$
WebMvcAutoConfigurationAdapter' via constructor to bean named 'spring.mvc-org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties'
2020-10-08 11:34:30.746 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$
WebMvcAutoConfigurationAdapter' via constructor to bean named 'org.springframework.beans.factory.support.DefaultListableBeanFactory@62e6b5c8'
2020-10-08 11:34:30.748 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.data.web.config.SpringDataWebConfiguration'
2020-10-08 11:34:30.749 DEBUG 9644 --- [           main] ocalVariableTableParameterNameDiscoverer : Cannot find '.class' file for class [class org.springframework.data.web.config.SpringDataWebConfiguration$$Enh
ancerBySpringCGLIB$$809854dc] - unable to determine constructor/method parameter names
2020-10-08 11:34:30.750 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.data.web.config.SpringDataWebConfiguration' via constru
ctor to bean named 'org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676cf48'
2020-10-08 11:34:30.753 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'pageableCustomizer'
2020-10-08 11:34:30.753 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoC
onfiguration'
2020-10-08 11:34:30.755 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.data.web-org.springframework.boot.autoconfigure.data.web.Sp
ringDataWebProperties'
2020-10-08 11:34:30.756 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfigurat
ion' via constructor to bean named 'spring.data.web-org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties'
2020-10-08 11:34:30.760 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'sortCustomizer'
2020-10-08 11:34:30.762 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'requestMappingHandlerAdapter'
2020-10-08 11:34:30.764 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mvcContentNegotiationManager'
2020-10-08 11:34:30.769 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mvcConversionService'
2020-10-08 11:34:30.778 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mvcValidator'
2020-10-08 11:34:30.783 DEBUG 9644 --- [           main] o.s.v.b.OptionalValidatorFactoryBean     : Failed to set up a Bean Validation provider

javax.validation.NoProviderFoundException: Unable to create a Configuration, because no Bean Validation provider could be found. Add a provider like Hibernate Validator (RI) to your classpath.
        at javax.validation.Validation$GenericBootstrapImpl.configure(Validation.java:291) ~[validation-api-2.0.1.Final.jar:na]
        at org.springframework.validation.beanvalidation.LocalValidatorFactoryBean.afterPropertiesSet(LocalValidatorFactoryBean.java:257) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.validation.beanvalidation.OptionalValidatorFactoryBean.afterPropertiesSet(OptionalValidatorFactoryBean.java:40) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.boot.autoconfigure.validation.ValidatorAdapter.afterPropertiesSet(ValidatorAdapter.java:83) ~[spring-boot-autoconfigure-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1853) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1790) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:594) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:516) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:324) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:322) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:276) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1307) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1227) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:884) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:788) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:538) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1336) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE
]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1176) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:556) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:516) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:324) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:322) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:897) ~[spring-beans-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:879) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:551) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:143) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:758) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:750) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:315) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1237) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1226) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at com.test.SpringMain.main(SpringMain.java:20) ~[classes/:na]

2020-10-08 11:34:30.784 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerAdapter' via factory method to bean named 'mvcContentN
egotiationManager'
2020-10-08 11:34:30.785 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerAdapter' via factory method to bean named 'mvcConversi
onService'
2020-10-08 11:34:30.785 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerAdapter' via factory method to bean named 'mvcValidato
r'
2020-10-08 11:34:30.789 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerAdapter' via factory method to bean named 'mvcContentN
egotiationManager'
2020-10-08 11:34:30.789 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerAdapter' via factory method to bean named 'mvcConversi
onService'
2020-10-08 11:34:30.790 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerAdapter' via factory method to bean named 'mvcValidato
r'
2020-10-08 11:34:30.795 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'messageConverters'
2020-10-08 11:34:30.795 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.http.HttpMessageConvertersA
utoConfiguration'
2020-10-08 11:34:30.798 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'stringHttpMessageConverter'
2020-10-08 11:34:30.808 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.http.HttpMessageConvertersA
utoConfiguration$StringHttpMessageConverterConfiguration'
2020-10-08 11:34:30.810 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'stringHttpMessageConverter' via factory method to bean named 'environment'
2020-10-08 11:34:30.816 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mappingJackson2HttpMessageConverter'
2020-10-08 11:34:30.816 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.http.JacksonHttpMessageConv
ertersConfiguration$MappingJackson2HttpMessageConverterConfiguration'
2020-10-08 11:34:30.817 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jacksonObjectMapper'
2020-10-08 11:34:30.818 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jackson.JacksonAutoConfigur
ation$JacksonObjectMapperConfiguration'
2020-10-08 11:34:30.819 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jackson.JacksonAutoConfigur
ation$JacksonObjectMapperBuilderConfiguration'
2020-10-08 11:34:30.820 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'standardJacksonObjectMapperBuilderCustomizer'
2020-10-08 11:34:30.820 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jackson.JacksonAutoConfigur
ation$Jackson2ObjectMapperBuilderCustomizerConfiguration'
2020-10-08 11:34:30.822 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.jackson-org.springframework.boot.autoconfigure.jackson.Jack
sonProperties'
2020-10-08 11:34:30.826 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'standardJacksonObjectMapperBuilderCustomizer' via factory method to bean na
med 'org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676cf48'
2020-10-08 11:34:30.826 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'standardJacksonObjectMapperBuilderCustomizer' via factory method to bean na
med 'spring.jackson-org.springframework.boot.autoconfigure.jackson.JacksonProperties'
2020-10-08 11:34:30.827 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jacksonObjectMapperBuilder' via factory method to bean named 'org.springfra
mework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676cf48'
2020-10-08 11:34:30.827 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jacksonObjectMapperBuilder' via factory method to bean named 'standardJacks
onObjectMapperBuilderCustomizer'
2020-10-08 11:34:30.829 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'parameterNamesModule'
2020-10-08 11:34:30.829 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jackson.JacksonAutoConfigur
ation$ParameterNamesModuleConfiguration'
2020-10-08 11:34:30.833 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jsonComponentModule'
2020-10-08 11:34:30.833 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jackson.JacksonAutoConfigur
ation'
2020-10-08 11:34:30.845 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jacksonGeoModule'
2020-10-08 11:34:30.845 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.data.web.config.SpringDataJacksonConfiguration
'
2020-10-08 11:34:30.850 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jacksonObjectMapper' via factory method to bean named 'jacksonObjectMapperB
uilder'
2020-10-08 11:34:30.880 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'mappingJackson2HttpMessageConverter' via factory method to bean named 'jack
sonObjectMapper'
2020-10-08 11:34:30.890 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'sortResolver'
2020-10-08 11:34:30.901 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'pageableResolver'
2020-10-08 11:34:30.906 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'applicationTaskExecutor'
2020-10-08 11:34:30.907 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'applicationTaskExecutor' via factory method to bean named 'taskExecutorBuil
der'
2020-10-08 11:34:30.910  INFO 9644 --- [           main] o.s.s.concurrent.ThreadPoolTaskExecutor  : Initializing ExecutorService 'applicationTaskExecutor'
2020-10-08 11:34:30.918 DEBUG 9644 --- [           main] s.w.s.m.m.a.RequestMappingHandlerAdapter : ControllerAdvice beans: 0 @ModelAttribute, 0 @InitBinder, 1 RequestBodyAdvice, 1 ResponseBodyAdvice
2020-10-08 11:34:30.933 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'requestMappingHandlerMapping'
2020-10-08 11:34:30.935 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mvcResourceUrlProvider'
2020-10-08 11:34:30.939 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerMapping' via factory method to bean named 'mvcContentN
egotiationManager'
2020-10-08 11:34:30.939 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerMapping' via factory method to bean named 'mvcConversi
onService'
2020-10-08 11:34:30.939 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerMapping' via factory method to bean named 'mvcResource
UrlProvider'
2020-10-08 11:34:30.940 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerMapping' via factory method to bean named 'mvcContentN
egotiationManager'
2020-10-08 11:34:30.940 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerMapping' via factory method to bean named 'mvcConversi
onService'
2020-10-08 11:34:30.941 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'requestMappingHandlerMapping' via factory method to bean named 'mvcResource
UrlProvider'
2020-10-08 11:34:30.971 DEBUG 9644 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : 2 mappings in 'requestMappingHandlerMapping'
2020-10-08 11:34:30.973 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'welcomePageHandlerMapping'
2020-10-08 11:34:30.974 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'welcomePageHandlerMapping' via factory method to bean named 'org.springfram
ework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676cf48'
2020-10-08 11:34:30.974 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'welcomePageHandlerMapping' via factory method to bean named 'mvcConversionS
ervice'
2020-10-08 11:34:30.974 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'welcomePageHandlerMapping' via factory method to bean named 'mvcResourceUrl
Provider'
2020-10-08 11:34:30.980 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mvcPathMatcher'
2020-10-08 11:34:30.981 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mvcUrlPathHelper'
2020-10-08 11:34:30.982 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'viewControllerHandlerMapping'
2020-10-08 11:34:30.984 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'viewControllerHandlerMapping' via factory method to bean named 'mvcPathMatc
her'
2020-10-08 11:34:30.984 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'viewControllerHandlerMapping' via factory method to bean named 'mvcUrlPathH
elper'
2020-10-08 11:34:30.996 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'viewControllerHandlerMapping' via factory method to bean named 'mvcConversi
onService'
2020-10-08 11:34:30.996 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'viewControllerHandlerMapping' via factory method to bean named 'mvcResource
UrlProvider'
2020-10-08 11:34:30.997 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'beanNameHandlerMapping'
2020-10-08 11:34:30.998 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'beanNameHandlerMapping' via factory method to bean named 'mvcConversionServ
ice'
2020-10-08 11:34:30.998 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'beanNameHandlerMapping' via factory method to bean named 'mvcResourceUrlPro
vider'
2020-10-08 11:34:31.001 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'routerFunctionMapping'
2020-10-08 11:34:31.002 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'routerFunctionMapping' via factory method to bean named 'mvcConversionServi
ce'
2020-10-08 11:34:31.002 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'routerFunctionMapping' via factory method to bean named 'mvcResourceUrlProv
ider'
2020-10-08 11:34:31.006 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'resourceHandlerMapping'
2020-10-08 11:34:31.007 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'resourceHandlerMapping' via factory method to bean named 'mvcUrlPathHelper'

2020-10-08 11:34:31.007 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'resourceHandlerMapping' via factory method to bean named 'mvcPathMatcher'
2020-10-08 11:34:31.007 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'resourceHandlerMapping' via factory method to bean named 'mvcContentNegotia
tionManager'
2020-10-08 11:34:31.007 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'resourceHandlerMapping' via factory method to bean named 'mvcConversionServ
ice'
2020-10-08 11:34:31.008 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'resourceHandlerMapping' via factory method to bean named 'mvcResourceUrlPro
vider'
2020-10-08 11:34:31.015 DEBUG 9644 --- [           main] o.s.w.s.handler.SimpleUrlHandlerMapping  : Patterns [/webjars/**, /**] in 'resourceHandlerMapping'
2020-10-08 11:34:31.016 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'defaultServletHandlerMapping'
2020-10-08 11:34:31.017 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'handlerFunctionAdapter'
2020-10-08 11:34:31.019 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mvcUriComponentsContributor'
2020-10-08 11:34:31.020 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'mvcUriComponentsContributor' via factory method to bean named 'mvcConversio
nService'
2020-10-08 11:34:31.020 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'mvcUriComponentsContributor' via factory method to bean named 'requestMappi
ngHandlerAdapter'
2020-10-08 11:34:31.022 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'httpRequestHandlerAdapter'
2020-10-08 11:34:31.023 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'simpleControllerHandlerAdapter'
2020-10-08 11:34:31.023 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'handlerExceptionResolver'
2020-10-08 11:34:31.024 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'handlerExceptionResolver' via factory method to bean named 'mvcContentNegot
iationManager'
2020-10-08 11:34:31.027 DEBUG 9644 --- [           main] .m.m.a.ExceptionHandlerExceptionResolver : ControllerAdvice beans: 0 @ExceptionHandler, 1 ResponseBodyAdvice
2020-10-08 11:34:31.029 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mvcViewResolver'
2020-10-08 11:34:31.030 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'mvcViewResolver' via factory method to bean named 'mvcContentNegotiationMan
ager'
2020-10-08 11:34:31.031 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'defaultViewResolver'
2020-10-08 11:34:31.038 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'viewResolver'
2020-10-08 11:34:31.039 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'viewResolver' via factory method to bean named 'org.springframework.beans.f
actory.support.DefaultListableBeanFactory@62e6b5c8'
2020-10-08 11:34:31.041 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mustacheViewResolver'
2020-10-08 11:34:31.042 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.mustache.MustacheServletWeb
Configuration'
2020-10-08 11:34:31.042 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mustacheCompiler'
2020-10-08 11:34:31.043 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.mustache.MustacheAutoConfig
uration'
2020-10-08 11:34:31.043 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.mustache-org.springframework.boot.autoconfigure.mustache.Mu
stacheProperties'
2020-10-08 11:34:31.047 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration'
via constructor to bean named 'spring.mustache-org.springframework.boot.autoconfigure.mustache.MustacheProperties'
2020-10-08 11:34:31.047 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration'
via constructor to bean named 'org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676cf48'
2020-10-08 11:34:31.048  WARN 9644 --- [           main] o.s.b.a.m.MustacheAutoConfiguration      : Cannot find template location: classpath:/templates/ (please add some templates, check your Mustache configura
tion, or set spring.mustache.check-template-location=false)
2020-10-08 11:34:31.049 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'mustacheTemplateLoader'
2020-10-08 11:34:31.050 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'mustacheCompiler' via factory method to bean named 'mustacheTemplateLoader'

2020-10-08 11:34:31.050 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'mustacheCompiler' via factory method to bean named 'environment'
2020-10-08 11:34:31.057 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'mustacheViewResolver' via factory method to bean named 'mustacheCompiler'
2020-10-08 11:34:31.057 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'mustacheViewResolver' via factory method to bean named 'spring.mustache-org
.springframework.boot.autoconfigure.mustache.MustacheProperties'
2020-10-08 11:34:31.061 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.aop.AopAutoConfiguration$Cl
assProxyingConfiguration'
2020-10-08 11:34:31.061 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.aop.AopAutoConfiguration$ClassProxyi
ngConfiguration' via constructor to bean named 'org.springframework.beans.factory.support.DefaultListableBeanFactory@62e6b5c8'
2020-10-08 11:34:31.063 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.aop.AopAutoConfiguration'
2020-10-08 11:34:31.064 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.availability.ApplicationAva
ilabilityAutoConfiguration'
2020-10-08 11:34:31.076 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'applicationAvailability'
2020-10-08 11:34:31.078 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.DataSourceConfiguratio
n$Hikari'
2020-10-08 11:34:31.079 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'dataSource'
2020-10-08 11:34:31.080 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.datasource-org.springframework.boot.autoconfigure.jdbc.Data
SourceProperties'
2020-10-08 11:34:31.089 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dataSource' via factory method to bean named 'spring.datasource-org.springf
ramework.boot.autoconfigure.jdbc.DataSourceProperties'
2020-10-08 11:34:31.100 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : Driver class org.postgresql.Driver found in Thread context class loader jdk.internal.loader.ClassLoaders$AppCl
assLoader@6e5e91e4
2020-10-08 11:34:31.123 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.DataSourceInitializerI
nvoker'
2020-10-08 11:34:31.125 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.jdbc.DataSourceInitializerInvoker' v
ia constructor to bean named 'spring.datasource-org.springframework.boot.autoconfigure.jdbc.DataSourceProperties'
2020-10-08 11:34:31.125 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.jdbc.DataSourceInitializerInvoker' v
ia constructor to bean named 'org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676cf48'
2020-10-08 11:34:31.129 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.DataSourceJmxConfigura
tion$Hikari'
2020-10-08 11:34:31.129 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.jdbc.DataSourceJmxConfiguration$Hika
ri' via constructor to bean named 'dataSource'
2020-10-08 11:34:31.131 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.DataSourceJmxConfigura
tion'
2020-10-08 11:34:31.132 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfigur
ation$PooledDataSourceConfiguration'
2020-10-08 11:34:31.132 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoo
lMetadataProvidersConfiguration$HikariPoolDataSourceMetadataProviderConfiguration'
2020-10-08 11:34:31.133 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'hikariPoolDataSourceMetadataProvider'
2020-10-08 11:34:31.134 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoo
lMetadataProvidersConfiguration'
2020-10-08 11:34:31.135 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.DataSourceInitializati
onConfiguration'
2020-10-08 11:34:31.136 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfigur
ation'
2020-10-08 11:34:31.137 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.context.ConfigurationProper
tiesAutoConfiguration'
2020-10-08 11:34:31.138 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.context.LifecycleAutoConfig
uration'
2020-10-08 11:34:31.139 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'lifecycleProcessor'
2020-10-08 11:34:31.141 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.lifecycle-org.springframework.boot.autoconfigure.context.Li
fecycleProperties'
2020-10-08 11:34:31.143 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'lifecycleProcessor' via factory method to bean named 'spring.lifecycle-org.
springframework.boot.autoconfigure.context.LifecycleProperties'
2020-10-08 11:34:31.156 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.dao.PersistenceExceptionTra
nslationAutoConfiguration'
2020-10-08 11:34:31.157 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.JdbcTemplateConfigurat
ion'
2020-10-08 11:34:31.157 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'flywayInitializer'
2020-10-08 11:34:31.158 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.flyway.FlywayAutoConfigurat
ion$FlywayConfiguration'
2020-10-08 11:34:31.159 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'flyway'
2020-10-08 11:34:31.161 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.flyway-org.springframework.boot.autoconfigure.flyway.Flyway
Properties'
2020-10-08 11:34:31.169 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'flyway' via factory method to bean named 'spring.flyway-org.springframework
.boot.autoconfigure.flyway.FlywayProperties'
2020-10-08 11:34:31.169 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'flyway' via factory method to bean named 'spring.datasource-org.springframe
work.boot.autoconfigure.jdbc.DataSourceProperties'
2020-10-08 11:34:31.170 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'flyway' via factory method to bean named 'org.springframework.boot.web.serv
let.context.AnnotationConfigServletWebServerApplicationContext@676cf48'
2020-10-08 11:34:31.186 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'flywayInitializer' via factory method to bean named 'flyway'
2020-10-08 11:34:31.192  INFO 9644 --- [           main] o.f.c.internal.license.VersionPrinter    : Flyway Community Edition 6.4.4 by Redgate
2020-10-08 11:34:31.193 DEBUG 9644 --- [           main] o.f.c.i.s.classpath.ClassPathScanner     : Scanning for classpath resources at 'classpath:db/migration' ...
2020-10-08 11:34:31.193 DEBUG 9644 --- [           main] o.f.c.i.s.classpath.ClassPathScanner     : Determining location urls for classpath:db/migration using ClassLoader jdk.internal.loader.ClassLoaders$AppCla
ssLoader@6e5e91e4 ...
2020-10-08 11:34:31.194 DEBUG 9644 --- [           main] o.f.c.i.s.classpath.ClassPathScanner     : Scanning URL: file:/D:/dev/projets/github/BrokenSpringBoot-1/target/classes/db/migration
2020-10-08 11:34:31.194 DEBUG 9644 --- [           main] o.f.core.internal.util.FeatureDetector   : JBoss VFS v2 available: false
2020-10-08 11:34:31.195 DEBUG 9644 --- [           main] i.s.c.FileSystemClassPathLocationScanner : Scanning starting at classpath root in filesystem: D:\dev\projets\github\BrokenSpringBoot-1\target\classes\
2020-10-08 11:34:31.195 DEBUG 9644 --- [           main] i.s.c.FileSystemClassPathLocationScanner : Scanning for resources in path: D:\dev\projets\github\BrokenSpringBoot-1\target\classes\db\migration (db/migra
tion)
2020-10-08 11:34:31.198 DEBUG 9644 --- [           main] o.f.c.i.s.classpath.ClassPathScanner     : Found resource: db/migration/V1_1_0__Init.sql
2020-10-08 11:34:31.198 DEBUG 9644 --- [           main] o.f.c.i.s.classpath.ClassPathScanner     : Scanning for classes at classpath:db/migration
2020-10-08 11:34:31.199 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : HikariPool-1 - configuration:
2020-10-08 11:34:31.201 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : allowPoolSuspension.............false
2020-10-08 11:34:31.202 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : autoCommit......................true
2020-10-08 11:34:31.202 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : catalog.........................none
2020-10-08 11:34:31.202 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : connectionInitSql...............none
2020-10-08 11:34:31.202 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : connectionTestQuery.............none
2020-10-08 11:34:31.202 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : connectionTimeout...............30000
2020-10-08 11:34:31.203 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : dataSource......................none
2020-10-08 11:34:31.203 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : dataSourceClassName.............none
2020-10-08 11:34:31.203 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : dataSourceJNDI..................none
2020-10-08 11:34:31.204 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : dataSourceProperties............{password=<masked>}
2020-10-08 11:34:31.204 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : driverClassName................."org.postgresql.Driver"
2020-10-08 11:34:31.204 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : exceptionOverrideClassName......none
2020-10-08 11:34:31.204 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : healthCheckProperties...........{}
2020-10-08 11:34:31.205 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : healthCheckRegistry.............none
2020-10-08 11:34:31.205 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : idleTimeout.....................600000
2020-10-08 11:34:31.205 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : initializationFailTimeout.......1
2020-10-08 11:34:31.205 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : isolateInternalQueries..........false
2020-10-08 11:34:31.206 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : jdbcUrl.........................jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:31.206 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : leakDetectionThreshold..........0
2020-10-08 11:34:31.206 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : maxLifetime.....................1800000
2020-10-08 11:34:31.206 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : maximumPoolSize.................10
2020-10-08 11:34:31.206 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : metricRegistry..................none
2020-10-08 11:34:31.207 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : metricsTrackerFactory...........none
2020-10-08 11:34:31.207 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : minimumIdle.....................10
2020-10-08 11:34:31.207 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : password........................<masked>
2020-10-08 11:34:31.207 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : poolName........................"HikariPool-1"
2020-10-08 11:34:31.207 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : readOnly........................false
2020-10-08 11:34:31.207 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : registerMbeans..................false
2020-10-08 11:34:31.208 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : scheduledExecutor...............none
2020-10-08 11:34:31.208 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : schema..........................none
2020-10-08 11:34:31.208 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : threadFactory...................internal
2020-10-08 11:34:31.208 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : transactionIsolation............default
2020-10-08 11:34:31.208 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : username........................"postgres"
2020-10-08 11:34:31.208 DEBUG 9644 --- [           main] com.zaxxer.hikari.HikariConfig           : validationTimeout...............5000
2020-10-08 11:34:31.208  INFO 9644 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
2020-10-08 11:34:31.219 DEBUG 9644 --- [           main] org.postgresql.Driver                    : Loading driver configuration via classloader jdk.internal.loader.ClassLoaders$AppClassLoader@6e5e91e4
2020-10-08 11:34:31.220 DEBUG 9644 --- [           main] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:31.224 DEBUG 9644 --- [           main] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:31.232 DEBUG 9644 --- [           main] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:31.233 DEBUG 9644 --- [           main] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:31.236 DEBUG 9644 --- [           main] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:31.260 DEBUG 9644 --- [           main] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:31.261 DEBUG 9644 --- [           main] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:32.174 DEBUG 9644 --- [           main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@33bb3f86
2020-10-08 11:34:32.176  INFO 9644 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
2020-10-08 11:34:32.195  INFO 9644 --- [           main] o.f.c.internal.database.DatabaseFactory  : Database: jdbc:postgresql://localhost:5432/myDB (PostgreSQL 11.0)
2020-10-08 11:34:32.195 DEBUG 9644 --- [           main] o.f.c.internal.database.DatabaseFactory  : Driver  : PostgreSQL JDBC Driver 42.2.16
**2020-10-08 11:34:32.196 DEBUG 9644 --- [           main] org.flywaydb.core.Flyway                 : DDL Transactions Supported: true
2020-10-08 11:34:32.196 DEBUG 9644 --- [           main] org.flywaydb.core.Flyway                 : Schemas:
2020-10-08 11:34:32.196 DEBUG 9644 --- [           main] org.flywaydb.core.Flyway                 : Default schema: null
2020-10-08 11:34:32.203 DEBUG 9644 --- [           main] o.f.c.i.c.SqlScriptCallbackFactory       : Scanning for SQL callbacks ...
2020-10-08 11:34:32.211 DEBUG 9644 --- [           main] o.f.core.internal.command.DbValidate     : Validating migrations ...
2020-10-08 11:34:32.213 DEBUG 9644 --- [           main] org.postgresql.jdbc.PgConnection         :   setAutoCommit = false
2020-10-08 11:34:32.225 DEBUG 9644 --- [           main] o.f.core.internal.scanner.Scanner        : Filtering out resource: db/migration/V1_1_0__Init.sql (filename: V1_1_0__Init.sql)
2020-10-08 11:34:32.238 DEBUG 9644 --- [           main] org.postgresql.jdbc.PgConnection         :   setAutoCommit = true
2020-10-08 11:34:32.238  INFO 9644 --- [           main] o.f.core.internal.command.DbValidate     : Successfully validated 1 migration (execution time 00:00.026s)
2020-10-08 11:34:32.244  INFO 9644 --- [           main] o.f.core.internal.command.DbMigrate      : Current version of schema "public": 1.1.0
2020-10-08 11:34:32.245  INFO 9644 --- [           main] o.f.core.internal.command.DbMigrate      : Schema "public" is up to date. No migration necessary.
2020-10-08 11:34:32.247 DEBUG 9644 --- [           main] org.postgresql.jdbc.PgConnection         :   setAutoCommit = false
2020-10-08 11:34:32.248 DEBUG 9644 --- [           main] org.postgresql.jdbc.PgConnection         :   setAutoCommit = true
2020-10-08 11:34:32.255 DEBUG 9644 --- [           main] org.flywaydb.core.Flyway                 : Memory usage: 20 of 504M**
2020-10-08 11:34:32.255 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jdbcTemplate'
2020-10-08 11:34:32.255 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.jdbc-org.springframework.boot.autoconfigure.jdbc.JdbcProper
ties'
2020-10-08 11:34:32.256 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcTemplate' via factory method to bean named 'dataSource'
2020-10-08 11:34:32.256 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcTemplate' via factory method to bean named 'spring.jdbc-org.springframe
work.boot.autoconfigure.jdbc.JdbcProperties'
2020-10-08 11:34:32.264 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.NamedParameterJdbcTemp
lateConfiguration'
2020-10-08 11:34:32.265 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'namedParameterJdbcTemplate'
2020-10-08 11:34:32.265 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'namedParameterJdbcTemplate' via factory method to bean named 'jdbcTemplate'

2020-10-08 11:34:32.268 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfig
uration'
2020-10-08 11:34:32.277 DEBUG 9644 --- [l-1 housekeeper] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Pool stats (total=1, active=0, idle=1, waiting=0)
2020-10-08 11:34:32.280 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionM
anagerAutoConfiguration$DataSourceTransactionManagerConfiguration'
2020-10-08 11:34:32.280 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'transactionManager'
2020-10-08 11:34:32.280 DEBUG 9644 --- [onnection adder] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:32.280 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'transactionManager' via factory method to bean named 'dataSource'
2020-10-08 11:34:32.281 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:32.281 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:32.281 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:32.282 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:32.282 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'platformTransactionManagerCustomizers'
2020-10-08 11:34:32.282 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.transaction.TransactionAuto
Configuration'
2020-10-08 11:34:32.283 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:32.283 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:32.284 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.transaction-org.springframework.boot.autoconfigure.transact
ion.TransactionProperties'
2020-10-08 11:34:32.289 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionM
anagerAutoConfiguration'
2020-10-08 11:34:32.290 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.data.jdbc.JdbcRepositoriesA
utoConfiguration$SpringBootJdbcConfiguration'
2020-10-08 11:34:32.290 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jdbcMappingContext'
2020-10-08 11:34:32.292 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jdbcCustomConversions'
2020-10-08 11:34:32.327 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.joda.time.LocalDate to class java.util.Date as writing converter.
2020-10-08 11:34:32.327 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.joda.time.LocalDateTime to class java.util.Date as writing converter.
2020-10-08 11:34:32.328 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.joda.time.DateTime to class java.util.Date as writing converter.
2020-10-08 11:34:32.328 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class org.joda.time.LocalDate as reading converter.
2020-10-08 11:34:32.328 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class org.joda.time.LocalDateTime as reading converter.
2020-10-08 11:34:32.328 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class org.joda.time.DateTime as reading converter.
2020-10-08 11:34:32.328 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.LocalDateTime to class org.joda.time.LocalDateTime as reading converter.

2020-10-08 11:34:32.328 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.LocalDateTime to class org.joda.time.DateTime as reading converter.
2020-10-08 11:34:32.329 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.Instant to class org.joda.time.LocalDateTime as reading converter.
2020-10-08 11:34:32.329 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.joda.time.LocalDateTime to class java.time.Instant as writing converter.
2020-10-08 11:34:32.329 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.joda.time.LocalDateTime to class java.time.LocalDateTime as writing converter.

2020-10-08 11:34:32.330 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class java.time.LocalDateTime as reading converter.
2020-10-08 11:34:32.330 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.LocalDateTime to class java.util.Date as writing converter.
2020-10-08 11:34:32.330 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class java.time.LocalDate as reading converter.
2020-10-08 11:34:32.331 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.LocalDate to class java.util.Date as writing converter.
2020-10-08 11:34:32.331 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class java.time.LocalTime as reading converter.
2020-10-08 11:34:32.331 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.LocalTime to class java.util.Date as writing converter.
2020-10-08 11:34:32.331 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class java.time.Instant as reading converter.
2020-10-08 11:34:32.331 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.Instant to class java.util.Date as writing converter.
2020-10-08 11:34:32.332 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.LocalDateTime to class java.time.Instant as reading converter.
2020-10-08 11:34:32.332 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.Instant to class java.time.LocalDateTime as reading converter.
2020-10-08 11:34:32.332 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.ZoneId to class java.lang.String as writing converter.
2020-10-08 11:34:32.332 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.lang.String to class java.time.ZoneId as reading converter.
2020-10-08 11:34:32.332 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.Duration to class java.lang.String as writing converter.
2020-10-08 11:34:32.332 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.lang.String to class java.time.Duration as reading converter.
2020-10-08 11:34:32.333 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.Period to class java.lang.String as writing converter.
2020-10-08 11:34:32.333 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.lang.String to class java.time.Period as reading converter.
2020-10-08 11:34:32.333 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.lang.String to class java.time.LocalDate as reading converter.
2020-10-08 11:34:32.333 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.lang.String to class java.time.LocalDateTime as reading converter.
2020-10-08 11:34:32.334 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.lang.String to class java.time.Instant as reading converter.
2020-10-08 11:34:32.334 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class org.threeten.bp.LocalDateTime as reading converter.
2020-10-08 11:34:32.334 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.threeten.bp.LocalDateTime to class java.util.Date as writing converter.
2020-10-08 11:34:32.334 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class org.threeten.bp.LocalDate as reading converter.
2020-10-08 11:34:32.335 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.threeten.bp.LocalDate to class java.util.Date as writing converter.
2020-10-08 11:34:32.335 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class org.threeten.bp.LocalTime as reading converter.
2020-10-08 11:34:32.335 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.threeten.bp.LocalTime to class java.util.Date as writing converter.
2020-10-08 11:34:32.335 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.util.Date to class org.threeten.bp.Instant as reading converter.
2020-10-08 11:34:32.336 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.threeten.bp.Instant to class java.util.Date as writing converter.
2020-10-08 11:34:32.336 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.threeten.bp.ZoneId to class java.lang.String as writing converter.
2020-10-08 11:34:32.336 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.lang.String to class org.threeten.bp.ZoneId as reading converter.
2020-10-08 11:34:32.337 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.threeten.bp.LocalDateTime to class java.time.LocalDateTime as writing converte
r.
2020-10-08 11:34:32.337 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class org.threeten.bp.LocalDateTime to class java.time.Instant as writing converter.
2020-10-08 11:34:32.337 DEBUG 9644 --- [           main] o.s.data.convert.CustomConversions       : Adding converter from class java.time.Instant to class org.threeten.bp.LocalDateTime as reading converter.
2020-10-08 11:34:32.338 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcMappingContext' via factory method to bean named 'jdbcCustomConversions
'
2020-10-08 11:34:32.354 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jdbcConverter'
2020-10-08 11:34:32.359 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jdbcDialect'
2020-10-08 11:34:32.360 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcDialect' via factory method to bean named 'namedParameterJdbcTemplate'
2020-10-08 11:34:32.364 DEBUG 9644 --- [           main] o.s.jdbc.datasource.DataSourceUtils      : Fetching JDBC Connection from DataSource
2020-10-08 11:34:32.374 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcConverter' via factory method to bean named 'jdbcMappingContext'
2020-10-08 11:34:32.376 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcConverter' via factory method to bean named 'namedParameterJdbcTemplate
'
2020-10-08 11:34:32.376 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcConverter' via factory method to bean named 'jdbcCustomConversions'
2020-10-08 11:34:32.376 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcConverter' via factory method to bean named 'jdbcDialect'
2020-10-08 11:34:32.380 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jdbcAggregateTemplate'
2020-10-08 11:34:32.381 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'dataAccessStrategyBean'
2020-10-08 11:34:32.383 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dataAccessStrategyBean' via factory method to bean named 'namedParameterJdb
cTemplate'
2020-10-08 11:34:32.383 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dataAccessStrategyBean' via factory method to bean named 'jdbcConverter'
2020-10-08 11:34:32.383 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dataAccessStrategyBean' via factory method to bean named 'jdbcMappingContex
t'
2020-10-08 11:34:32.383 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dataAccessStrategyBean' via factory method to bean named 'jdbcDialect'
2020-10-08 11:34:32.388 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcAggregateTemplate' via factory method to bean named 'org.springframewor
k.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676cf48'
2020-10-08 11:34:32.388 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcAggregateTemplate' via factory method to bean named 'jdbcMappingContext
'
2020-10-08 11:34:32.388 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcAggregateTemplate' via factory method to bean named 'jdbcConverter'
2020-10-08 11:34:32.388 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jdbcAggregateTemplate' via factory method to bean named 'dataAccessStrategy
Bean'
2020-10-08 11:34:32.394 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.data.jdbc.JdbcRepositoriesA
utoConfiguration$JdbcRepositoriesConfiguration'
2020-10-08 11:34:32.395 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.data.jdbc.JdbcRepositoriesA
utoConfiguration'
2020-10-08 11:34:32.395 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration'

2020-10-08 11:34:32.395 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'gsonBuilder'
2020-10-08 11:34:32.396 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'standardGsonBuilderCustomizer'
2020-10-08 11:34:32.396 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.gson-org.springframework.boot.autoconfigure.gson.GsonProper
ties'
2020-10-08 11:34:32.399 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'standardGsonBuilderCustomizer' via factory method to bean named 'spring.gso
n-org.springframework.boot.autoconfigure.gson.GsonProperties'
2020-10-08 11:34:32.399 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'gsonBuilder' via factory method to bean named 'standardGsonBuilderCustomize
r'
2020-10-08 11:34:32.408 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'gson'
2020-10-08 11:34:32.408 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'gson' via factory method to bean named 'gsonBuilder'
2020-10-08 11:34:32.429 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.http.JacksonHttpMessageConv
ertersConfiguration'
2020-10-08 11:34:32.429 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.http.GsonHttpMessageConvert
ersConfiguration'
2020-10-08 11:34:32.430 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.data.web.config.ProjectingArgumentResolverRegi
strar'
2020-10-08 11:34:32.430 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'flywayDefaultDdlModeProvider'
2020-10-08 11:34:32.431 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfigu
ration'
2020-10-08 11:34:32.434 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.info-org.springframework.boot.autoconfigure.info.ProjectInf
oProperties'
2020-10-08 11:34:32.446 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration' v
ia constructor to bean named 'spring.info-org.springframework.boot.autoconfigure.info.ProjectInfoProperties'
2020-10-08 11:34:32.446 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.transaction.TransactionAuto
Configuration$EnableTransactionManagementConfiguration$CglibAutoProxyConfiguration'
2020-10-08 11:34:32.446 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.transaction.TransactionAuto
Configuration$EnableTransactionManagementConfiguration'
2020-10-08 11:34:32.448 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.transaction.TransactionAuto
Configuration$TransactionTemplateConfiguration'
2020-10-08 11:34:32.448 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'transactionTemplate'
2020-10-08 11:34:32.448 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'transactionTemplate' via factory method to bean named 'transactionManager'
2020-10-08 11:34:32.450 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration$
DslContextConfiguration'
2020-10-08 11:34:32.450 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'dslContext'
2020-10-08 11:34:32.450 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jooqConfiguration'
2020-10-08 11:34:32.454 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.jooq-org.springframework.boot.autoconfigure.jooq.JooqProper
ties'
2020-10-08 11:34:32.456 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'dataSourceConnectionProvider'
2020-10-08 11:34:32.456 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration'

2020-10-08 11:34:32.456 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dataSourceConnectionProvider' via factory method to bean named 'dataSource'

2020-10-08 11:34:32.457 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jooqConfiguration' via factory method to bean named 'spring.jooq-org.spring
framework.boot.autoconfigure.jooq.JooqProperties'
2020-10-08 11:34:32.457 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jooqConfiguration' via factory method to bean named 'dataSourceConnectionPr
ovider'
2020-10-08 11:34:32.457 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'jooqConfiguration' via factory method to bean named 'dataSource'
2020-10-08 11:34:32.467 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'transactionProvider'
2020-10-08 11:34:32.467 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'transactionProvider' via factory method to bean named 'transactionManager'
2020-10-08 11:34:32.472 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'jooqExceptionTranslatorExecuteListenerProvider'
2020-10-08 11:34:32.479 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'dslContext' via factory method to bean named 'jooqConfiguration'
2020-10-08 11:34:32.807 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConf
iguration'
2020-10-08 11:34:32.807 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'taskScheduler'
2020-10-08 11:34:32.808 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'taskSchedulerBuilder'
2020-10-08 11:34:32.808 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'spring.task.scheduling-org.springframework.boot.autoconfigure.task
.TaskSchedulingProperties'
2020-10-08 11:34:32.809 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'taskSchedulerBuilder' via factory method to bean named 'spring.task.schedul
ing-org.springframework.boot.autoconfigure.task.TaskSchedulingProperties'
2020-10-08 11:34:32.810 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Autowiring by type from bean name 'taskScheduler' via factory method to bean named 'taskSchedulerBuilder'
2020-10-08 11:34:32.812  INFO 9644 --- [           main] o.s.s.c.ThreadPoolTaskScheduler          : Initializing ExecutorService 'taskScheduler'
2020-10-08 11:34:32.813 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.client.RestTemplateAuto
Configuration'
2020-10-08 11:34:32.814 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebSer
verFactoryCustomizerAutoConfiguration'
2020-10-08 11:34:32.814 DEBUG 9644 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Creating shared instance of singleton bean 'multipartResolver'
2020-10-08 11:34:32.857 DEBUG 9644 --- [           main] o.s.c.support.DefaultLifecycleProcessor  : Starting beans in phase 2147483646
2020-10-08 11:34:32.885 DEBUG 9644 --- [o-8080-Acceptor] o.apache.tomcat.util.threads.LimitLatch  : Counting up[http-nio-8080-Acceptor] latch=0
2020-10-08 11:34:32.890  INFO 9644 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
2020-10-08 11:34:32.892 DEBUG 9644 --- [           main] o.s.c.support.DefaultLifecycleProcessor  : Successfully started bean 'webServerStartStop'
2020-10-08 11:34:32.892 DEBUG 9644 --- [           main] o.s.c.support.DefaultLifecycleProcessor  : Starting beans in phase 2147483647
2020-10-08 11:34:32.892 DEBUG 9644 --- [           main] o.s.c.support.DefaultLifecycleProcessor  : Successfully started bean 'webServerGracefulShutdown'
2020-10-08 11:34:32.910 DEBUG 9644 --- [           main] ConditionEvaluationReportLoggingListener :


============================
CONDITIONS EVALUATION REPORT
============================


Positive matches:
-----------------

   AopAutoConfiguration matched:
      - @ConditionalOnProperty (spring.aop.auto=true) matched (OnPropertyCondition)

   AopAutoConfiguration.ClassProxyingConfiguration matched:
      - @ConditionalOnMissingClass did not find unwanted class 'org.aspectj.weaver.Advice' (OnClassCondition)
      - @ConditionalOnProperty (spring.aop.proxy-target-class=true) matched (OnPropertyCondition)

   DataSourceAutoConfiguration matched:
      - @ConditionalOnClass found required classes 'javax.sql.DataSource', 'org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType' (OnClassCondition)
      - @ConditionalOnMissingBean (types: io.r2dbc.spi.ConnectionFactory; SearchStrategy: all) did not find any beans (OnBeanCondition)

   DataSourceAutoConfiguration.PooledDataSourceConfiguration matched:
      - AnyNestedCondition 1 matched 1 did not; NestedCondition on DataSourceAutoConfiguration.PooledDataSourceCondition.PooledDataSourceAvailable PooledDataSource found supported DataSource; NestedCondition on
 DataSourceAutoConfiguration.PooledDataSourceCondition.ExplicitType @ConditionalOnProperty (spring.datasource.type) did not find property 'type' (DataSourceAutoConfiguration.PooledDataSourceCondition)
      - @ConditionalOnMissingBean (types: javax.sql.DataSource,javax.sql.XADataSource; SearchStrategy: all) did not find any beans (OnBeanCondition)

   DataSourceConfiguration.Hikari matched:
      - @ConditionalOnClass found required class 'com.zaxxer.hikari.HikariDataSource' (OnClassCondition)
      - @ConditionalOnProperty (spring.datasource.type=com.zaxxer.hikari.HikariDataSource) matched (OnPropertyCondition)
      - @ConditionalOnMissingBean (types: javax.sql.DataSource; SearchStrategy: all) did not find any beans (OnBeanCondition)

   DataSourceJmxConfiguration matched:
      - @ConditionalOnProperty (spring.jmx.enabled=true) matched (OnPropertyCondition)

   DataSourceJmxConfiguration.Hikari matched:
      - @ConditionalOnClass found required class 'com.zaxxer.hikari.HikariDataSource' (OnClassCondition)
      - @ConditionalOnSingleCandidate (types: javax.sql.DataSource; SearchStrategy: all) found a primary bean from beans 'dataSource' (OnBeanCondition)

   DataSourcePoolMetadataProvidersConfiguration.HikariPoolDataSourceMetadataProviderConfiguration matched:
      - @ConditionalOnClass found required class 'com.zaxxer.hikari.HikariDataSource' (OnClassCondition)

   DataSourceTransactionManagerAutoConfiguration matched:
      - @ConditionalOnClass found required classes 'org.springframework.jdbc.core.JdbcTemplate', 'org.springframework.transaction.PlatformTransactionManager' (OnClassCondition)

   DataSourceTransactionManagerAutoConfiguration.DataSourceTransactionManagerConfiguration matched:
      - @ConditionalOnSingleCandidate (types: javax.sql.DataSource; SearchStrategy: all) found a primary bean from beans 'dataSource' (OnBeanCondition)

   DataSourceTransactionManagerAutoConfiguration.DataSourceTransactionManagerConfiguration#transactionManager matched:
      - @ConditionalOnMissingBean (types: org.springframework.transaction.PlatformTransactionManager; SearchStrategy: all) did not find any beans (OnBeanCondition)

   DispatcherServletAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.web.servlet.DispatcherServlet' (OnClassCondition)
      - found 'session' scope (OnWebApplicationCondition)

   DispatcherServletAutoConfiguration.DispatcherServletConfiguration matched:
      - @ConditionalOnClass found required class 'javax.servlet.ServletRegistration' (OnClassCondition)
      - Default DispatcherServlet did not find dispatcher servlet beans (DispatcherServletAutoConfiguration.DefaultDispatcherServletCondition)

   DispatcherServletAutoConfiguration.DispatcherServletRegistrationConfiguration matched:
      - @ConditionalOnClass found required class 'javax.servlet.ServletRegistration' (OnClassCondition)
      - DispatcherServlet Registration did not find servlet registration bean (DispatcherServletAutoConfiguration.DispatcherServletRegistrationCondition)

   DispatcherServletAutoConfiguration.DispatcherServletRegistrationConfiguration#dispatcherServletRegistration matched:
      - @ConditionalOnBean (names: dispatcherServlet types: org.springframework.web.servlet.DispatcherServlet; SearchStrategy: all) found bean 'dispatcherServlet' (OnBeanCondition)

   EmbeddedWebServerFactoryCustomizerAutoConfiguration matched:
      - @ConditionalOnWebApplication (required) found 'session' scope (OnWebApplicationCondition)

   EmbeddedWebServerFactoryCustomizerAutoConfiguration.TomcatWebServerFactoryCustomizerConfiguration matched:
      - @ConditionalOnClass found required classes 'org.apache.catalina.startup.Tomcat', 'org.apache.coyote.UpgradeProtocol' (OnClassCondition)

   ErrorMvcAutoConfiguration matched:
      - @ConditionalOnClass found required classes 'javax.servlet.Servlet', 'org.springframework.web.servlet.DispatcherServlet' (OnClassCondition)
      - found 'session' scope (OnWebApplicationCondition)

   ErrorMvcAutoConfiguration#basicErrorController matched:
      - @ConditionalOnMissingBean (types: org.springframework.boot.web.servlet.error.ErrorController; SearchStrategy: current) did not find any beans (OnBeanCondition)

   ErrorMvcAutoConfiguration#errorAttributes matched:
      - @ConditionalOnMissingBean (types: org.springframework.boot.web.servlet.error.ErrorAttributes; SearchStrategy: current) did not find any beans (OnBeanCondition)

   ErrorMvcAutoConfiguration.DefaultErrorViewResolverConfiguration#conventionErrorViewResolver matched:
      - @ConditionalOnBean (types: org.springframework.web.servlet.DispatcherServlet; SearchStrategy: all) found bean 'dispatcherServlet'; @ConditionalOnMissingBean (types: org.springframework.boot.autoconfigur
e.web.servlet.error.ErrorViewResolver; SearchStrategy: all) did not find any beans (OnBeanCondition)

   ErrorMvcAutoConfiguration.WhitelabelErrorViewConfiguration matched:
      - @ConditionalOnProperty (server.error.whitelabel.enabled) matched (OnPropertyCondition)
      - ErrorTemplate Missing did not find error template view (ErrorMvcAutoConfiguration.ErrorTemplateMissingCondition)

   ErrorMvcAutoConfiguration.WhitelabelErrorViewConfiguration#beanNameViewResolver matched:
      - @ConditionalOnMissingBean (types: org.springframework.web.servlet.view.BeanNameViewResolver; SearchStrategy: all) did not find any beans (OnBeanCondition)

   ErrorMvcAutoConfiguration.WhitelabelErrorViewConfiguration#defaultErrorView matched:
      - @ConditionalOnMissingBean (names: error; SearchStrategy: all) did not find any beans (OnBeanCondition)

   FlywayAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.flywaydb.core.Flyway' (OnClassCondition)
      - @ConditionalOnProperty (spring.flyway.enabled) matched (OnPropertyCondition)
      - AnyNestedCondition 1 matched 1 did not; NestedCondition on FlywayAutoConfiguration.FlywayDataSourceCondition.FlywayUrlCondition @ConditionalOnProperty (spring.flyway.url) did not find property 'url'; Ne
stedCondition on FlywayAutoConfiguration.FlywayDataSourceCondition.DataSourceBeanCondition @ConditionalOnBean (types: javax.sql.DataSource; SearchStrategy: all) found bean 'dataSource' (FlywayAutoConfiguration.
FlywayDataSourceCondition)

   FlywayAutoConfiguration.FlywayConfiguration matched:
      - @ConditionalOnMissingBean (types: org.flywaydb.core.Flyway; SearchStrategy: all) did not find any beans (OnBeanCondition)

   FlywayAutoConfiguration.FlywayConfiguration#flywayInitializer matched:
      - @ConditionalOnMissingBean (types: org.springframework.boot.autoconfigure.flyway.FlywayMigrationInitializer; SearchStrategy: all) did not find any beans (OnBeanCondition)

   FlywayAutoConfiguration.FlywayJdbcOperationsDependsOnPostProcessor matched:
      - @ConditionalOnClass found required class 'org.springframework.jdbc.core.JdbcOperations' (OnClassCondition)
      - @ConditionalOnBean (types: org.springframework.jdbc.core.JdbcOperations; SearchStrategy: all) found bean 'jdbcTemplate' (OnBeanCondition)

   FlywayAutoConfiguration.FlywayMigrationInitializerJdbcOperationsDependsOnPostProcessor matched:
      - @ConditionalOnClass found required class 'org.springframework.jdbc.core.JdbcOperations' (OnClassCondition)
      - @ConditionalOnBean (types: org.springframework.jdbc.core.JdbcOperations; SearchStrategy: all) found bean 'jdbcTemplate' (OnBeanCondition)

   FlywayAutoConfiguration.FlywayMigrationInitializerNamedParameterJdbcOperationsDependsOnPostProcessor matched:
      - @ConditionalOnClass found required class 'org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations' (OnClassCondition)
      - @ConditionalOnBean (types: org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations; SearchStrategy: all) found bean 'namedParameterJdbcTemplate' (OnBeanCondition)

   FlywayAutoConfiguration.FlywayNamedParameterJdbcOperationsDependencyConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations' (OnClassCondition)
      - @ConditionalOnBean (types: org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations; SearchStrategy: all) found bean 'namedParameterJdbcTemplate' (OnBeanCondition)

   GenericCacheConfiguration matched:
      - Cache org.springframework.boot.autoconfigure.cache.GenericCacheConfiguration automatic cache type (CacheCondition)

   GsonAutoConfiguration matched:
      - @ConditionalOnClass found required class 'com.google.gson.Gson' (OnClassCondition)

   GsonAutoConfiguration#gson matched:
      - @ConditionalOnMissingBean (types: com.google.gson.Gson; SearchStrategy: all) did not find any beans (OnBeanCondition)

   GsonAutoConfiguration#gsonBuilder matched:
      - @ConditionalOnMissingBean (types: com.google.gson.GsonBuilder; SearchStrategy: all) did not find any beans (OnBeanCondition)

   GsonHttpMessageConvertersConfiguration matched:
      - @ConditionalOnClass found required class 'com.google.gson.Gson' (OnClassCondition)

   HttpEncodingAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.web.filter.CharacterEncodingFilter' (OnClassCondition)
      - found 'session' scope (OnWebApplicationCondition)
      - @ConditionalOnProperty (server.servlet.encoding.enabled) matched (OnPropertyCondition)

   HttpEncodingAutoConfiguration#characterEncodingFilter matched:
      - @ConditionalOnMissingBean (types: org.springframework.web.filter.CharacterEncodingFilter; SearchStrategy: all) did not find any beans (OnBeanCondition)

   HttpMessageConvertersAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.http.converter.HttpMessageConverter' (OnClassCondition)
      - NoneNestedConditions 0 matched 1 did not; NestedCondition on HttpMessageConvertersAutoConfiguration.NotReactiveWebApplicationCondition.ReactiveWebApplication did not find reactive web application classe
s (HttpMessageConvertersAutoConfiguration.NotReactiveWebApplicationCondition)

   HttpMessageConvertersAutoConfiguration#messageConverters matched:
      - @ConditionalOnMissingBean (types: org.springframework.boot.autoconfigure.http.HttpMessageConverters; SearchStrategy: all) did not find any beans (OnBeanCondition)

   HttpMessageConvertersAutoConfiguration.StringHttpMessageConverterConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.http.converter.StringHttpMessageConverter' (OnClassCondition)

   HttpMessageConvertersAutoConfiguration.StringHttpMessageConverterConfiguration#stringHttpMessageConverter matched:
      - @ConditionalOnMissingBean (types: org.springframework.http.converter.StringHttpMessageConverter; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JacksonAutoConfiguration matched:
      - @ConditionalOnClass found required class 'com.fasterxml.jackson.databind.ObjectMapper' (OnClassCondition)

   JacksonAutoConfiguration.Jackson2ObjectMapperBuilderCustomizerConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.http.converter.json.Jackson2ObjectMapperBuilder' (OnClassCondition)

   JacksonAutoConfiguration.JacksonObjectMapperBuilderConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.http.converter.json.Jackson2ObjectMapperBuilder' (OnClassCondition)

   JacksonAutoConfiguration.JacksonObjectMapperBuilderConfiguration#jacksonObjectMapperBuilder matched:
      - @ConditionalOnMissingBean (types: org.springframework.http.converter.json.Jackson2ObjectMapperBuilder; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JacksonAutoConfiguration.JacksonObjectMapperConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.http.converter.json.Jackson2ObjectMapperBuilder' (OnClassCondition)

   JacksonAutoConfiguration.JacksonObjectMapperConfiguration#jacksonObjectMapper matched:
      - @ConditionalOnMissingBean (types: com.fasterxml.jackson.databind.ObjectMapper; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JacksonAutoConfiguration.ParameterNamesModuleConfiguration matched:
      - @ConditionalOnClass found required class 'com.fasterxml.jackson.module.paramnames.ParameterNamesModule' (OnClassCondition)

   JacksonAutoConfiguration.ParameterNamesModuleConfiguration#parameterNamesModule matched:
      - @ConditionalOnMissingBean (types: com.fasterxml.jackson.module.paramnames.ParameterNamesModule; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JacksonHttpMessageConvertersConfiguration.MappingJackson2HttpMessageConverterConfiguration matched:
      - @ConditionalOnClass found required class 'com.fasterxml.jackson.databind.ObjectMapper' (OnClassCondition)
      - @ConditionalOnProperty (spring.mvc.converters.preferred-json-mapper=jackson) matched (OnPropertyCondition)
      - @ConditionalOnBean (types: com.fasterxml.jackson.databind.ObjectMapper; SearchStrategy: all) found bean 'jacksonObjectMapper' (OnBeanCondition)

   JacksonHttpMessageConvertersConfiguration.MappingJackson2HttpMessageConverterConfiguration#mappingJackson2HttpMessageConverter matched:
      - @ConditionalOnMissingBean (types: org.springframework.http.converter.json.MappingJackson2HttpMessageConverter ignored: org.springframework.hateoas.server.mvc.TypeConstrainedMappingJackson2HttpMessageCon
verter,org.springframework.data.rest.webmvc.alps.AlpsJsonHttpMessageConverter; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JdbcRepositoriesAutoConfiguration matched:
      - @ConditionalOnClass found required classes 'org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations', 'org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration' (OnClassCo
ndition)
      - @ConditionalOnProperty (spring.data.jdbc.repositories.enabled=true) matched (OnPropertyCondition)
      - @ConditionalOnBean (types: org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations,org.springframework.transaction.PlatformTransactionManager; SearchStrategy: all) found beans 'transaction
Manager', 'namedParameterJdbcTemplate' (OnBeanCondition)

   JdbcRepositoriesAutoConfiguration.JdbcRepositoriesConfiguration matched:
      - @ConditionalOnMissingBean (types: org.springframework.data.jdbc.repository.config.JdbcRepositoryConfigExtension; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JdbcRepositoriesAutoConfiguration.SpringBootJdbcConfiguration matched:
      - @ConditionalOnMissingBean (types: org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JdbcTemplateAutoConfiguration matched:
      - @ConditionalOnClass found required classes 'javax.sql.DataSource', 'org.springframework.jdbc.core.JdbcTemplate' (OnClassCondition)
      - @ConditionalOnSingleCandidate (types: javax.sql.DataSource; SearchStrategy: all) found a primary bean from beans 'dataSource' (OnBeanCondition)

   JdbcTemplateConfiguration matched:
      - @ConditionalOnMissingBean (types: org.springframework.jdbc.core.JdbcOperations; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JooqAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.jooq.DSLContext' (OnClassCondition)
      - @ConditionalOnBean (types: javax.sql.DataSource; SearchStrategy: all) found bean 'dataSource' (OnBeanCondition)

   JooqAutoConfiguration#dataSourceConnectionProvider matched:
      - @ConditionalOnMissingBean (types: org.jooq.ConnectionProvider; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JooqAutoConfiguration#transactionProvider matched:
      - @ConditionalOnBean (types: org.springframework.transaction.PlatformTransactionManager; SearchStrategy: all) found bean 'transactionManager' (OnBeanCondition)

   JooqAutoConfiguration.DslContextConfiguration matched:
      - @ConditionalOnMissingBean (types: org.jooq.DSLContext; SearchStrategy: all) did not find any beans (OnBeanCondition)

   JooqAutoConfiguration.DslContextConfiguration#jooqConfiguration matched:
      - @ConditionalOnMissingBean (types: org.jooq.Configuration; SearchStrategy: all) did not find any beans (OnBeanCondition)

   LifecycleAutoConfiguration#defaultLifecycleProcessor matched:
      - @ConditionalOnMissingBean (names: lifecycleProcessor; SearchStrategy: current) did not find any beans (OnBeanCondition)

   MultipartAutoConfiguration matched:
      - @ConditionalOnClass found required classes 'javax.servlet.Servlet', 'org.springframework.web.multipart.support.StandardServletMultipartResolver', 'javax.servlet.MultipartConfigElement' (OnClassCondition
)
      - found 'session' scope (OnWebApplicationCondition)
      - @ConditionalOnProperty (spring.servlet.multipart.enabled) matched (OnPropertyCondition)

   MultipartAutoConfiguration#multipartConfigElement matched:
      - @ConditionalOnMissingBean (types: javax.servlet.MultipartConfigElement,org.springframework.web.multipart.commons.CommonsMultipartResolver; SearchStrategy: all) did not find any beans (OnBeanCondition)

   MultipartAutoConfiguration#multipartResolver matched:
      - @ConditionalOnMissingBean (types: org.springframework.web.multipart.MultipartResolver; SearchStrategy: all) did not find any beans (OnBeanCondition)

   MustacheAutoConfiguration matched:
      - @ConditionalOnClass found required class 'com.samskivert.mustache.Mustache' (OnClassCondition)

   MustacheAutoConfiguration#mustacheCompiler matched:
      - @ConditionalOnMissingBean (types: com.samskivert.mustache.Mustache$Compiler; SearchStrategy: all) did not find any beans (OnBeanCondition)

   MustacheAutoConfiguration#mustacheTemplateLoader matched:
      - @ConditionalOnMissingBean (types: com.samskivert.mustache.Mustache$TemplateLoader; SearchStrategy: all) did not find any beans (OnBeanCondition)

   MustacheServletWebConfiguration matched:
      - found 'session' scope (OnWebApplicationCondition)

   MustacheServletWebConfiguration#mustacheViewResolver matched:
      - @ConditionalOnMissingBean (types: org.springframework.boot.web.servlet.view.MustacheViewResolver; SearchStrategy: all) did not find any beans (OnBeanCondition)

   NamedParameterJdbcTemplateConfiguration matched:
      - @ConditionalOnSingleCandidate (types: org.springframework.jdbc.core.JdbcTemplate; SearchStrategy: all) found a primary bean from beans 'jdbcTemplate'; @ConditionalOnMissingBean (types: org.springframewo
rk.jdbc.core.namedparam.NamedParameterJdbcOperations; SearchStrategy: all) did not find any beans (OnBeanCondition)

   NoOpCacheConfiguration matched:
      - Cache org.springframework.boot.autoconfigure.cache.NoOpCacheConfiguration automatic cache type (CacheCondition)

   PersistenceExceptionTranslationAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor' (OnClassCondition)

   PersistenceExceptionTranslationAutoConfiguration#persistenceExceptionTranslationPostProcessor matched:
      - @ConditionalOnProperty (spring.dao.exceptiontranslation.enabled) matched (OnPropertyCondition)
      - @ConditionalOnMissingBean (types: org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor; SearchStrategy: all) did not find any beans (OnBeanCondition)

   PropertyPlaceholderAutoConfiguration#propertySourcesPlaceholderConfigurer matched:
      - @ConditionalOnMissingBean (types: org.springframework.context.support.PropertySourcesPlaceholderConfigurer; SearchStrategy: current) did not find any beans (OnBeanCondition)

   RestTemplateAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.web.client.RestTemplate' (OnClassCondition)
      - NoneNestedConditions 0 matched 1 did not; NestedCondition on RestTemplateAutoConfiguration.NotReactiveWebApplicationCondition.ReactiveWebApplication did not find reactive web application classes (RestTe
mplateAutoConfiguration.NotReactiveWebApplicationCondition)

   RestTemplateAutoConfiguration#restTemplateBuilder matched:
      - @ConditionalOnMissingBean (types: org.springframework.boot.web.client.RestTemplateBuilder; SearchStrategy: all) did not find any beans (OnBeanCondition)

   ServletWebServerFactoryAutoConfiguration matched:
      - @ConditionalOnClass found required class 'javax.servlet.ServletRequest' (OnClassCondition)
      - found 'session' scope (OnWebApplicationCondition)

   ServletWebServerFactoryAutoConfiguration#tomcatServletWebServerFactoryCustomizer matched:
      - @ConditionalOnClass found required class 'org.apache.catalina.startup.Tomcat' (OnClassCondition)

   ServletWebServerFactoryConfiguration.EmbeddedTomcat matched:
      - @ConditionalOnClass found required classes 'javax.servlet.Servlet', 'org.apache.catalina.startup.Tomcat', 'org.apache.coyote.UpgradeProtocol' (OnClassCondition)
      - @ConditionalOnMissingBean (types: org.springframework.boot.web.servlet.server.ServletWebServerFactory; SearchStrategy: current) did not find any beans (OnBeanCondition)

   SimpleCacheConfiguration matched:
      - Cache org.springframework.boot.autoconfigure.cache.SimpleCacheConfiguration automatic cache type (CacheCondition)

   SpringDataWebAutoConfiguration matched:
      - @ConditionalOnClass found required classes 'org.springframework.data.web.PageableHandlerMethodArgumentResolver', 'org.springframework.web.servlet.config.annotation.WebMvcConfigurer' (OnClassCondition)
      - found 'session' scope (OnWebApplicationCondition)
      - @ConditionalOnMissingBean (types: org.springframework.data.web.PageableHandlerMethodArgumentResolver; SearchStrategy: all) did not find any beans (OnBeanCondition)

   SpringDataWebAutoConfiguration#pageableCustomizer matched:
      - @ConditionalOnMissingBean (types: org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer; SearchStrategy: all) did not find any beans (OnBeanCondition)

   SpringDataWebAutoConfiguration#sortCustomizer matched:
      - @ConditionalOnMissingBean (types: org.springframework.data.web.config.SortHandlerMethodArgumentResolverCustomizer; SearchStrategy: all) did not find any beans (OnBeanCondition)

   TaskExecutionAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor' (OnClassCondition)

   TaskExecutionAutoConfiguration#applicationTaskExecutor matched:
      - @ConditionalOnMissingBean (types: java.util.concurrent.Executor; SearchStrategy: all) did not find any beans (OnBeanCondition)

   TaskExecutionAutoConfiguration#taskExecutorBuilder matched:
      - @ConditionalOnMissingBean (types: org.springframework.boot.task.TaskExecutorBuilder; SearchStrategy: all) did not find any beans (OnBeanCondition)

   TaskSchedulingAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler' (OnClassCondition)

   TaskSchedulingAutoConfiguration#taskScheduler matched:
      - @ConditionalOnBean (names: org.springframework.context.annotation.internalScheduledAnnotationProcessor; SearchStrategy: all) found bean 'org.springframework.context.annotation.internalScheduledAnnotatio
nProcessor'; @ConditionalOnMissingBean (types: org.springframework.scheduling.annotation.SchedulingConfigurer,org.springframework.scheduling.TaskScheduler,java.util.concurrent.ScheduledExecutorService; SearchSt
rategy: all) did not find any beans (OnBeanCondition)

   TaskSchedulingAutoConfiguration#taskSchedulerBuilder matched:
      - @ConditionalOnMissingBean (types: org.springframework.boot.task.TaskSchedulerBuilder; SearchStrategy: all) did not find any beans (OnBeanCondition)

   TransactionAutoConfiguration matched:
      - @ConditionalOnClass found required class 'org.springframework.transaction.PlatformTransactionManager' (OnClassCondition)

   TransactionAutoConfiguration#platformTransactionManagerCustomizers matched:
      - @ConditionalOnMissingBean (types: org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers; SearchStrategy: all) did not find any beans (OnBeanCondition)

   TransactionAutoConfiguration.EnableTransactionManagementConfiguration matched:
      - @ConditionalOnBean (types: org.springframework.transaction.TransactionManager; SearchStrategy: all) found bean 'transactionManager'; @ConditionalOnMissingBean (types: org.springframework.transaction.ann
otation.AbstractTransactionManagementConfiguration; SearchStrategy: all) did not find any beans (OnBeanCondition)

   TransactionAutoConfiguration.EnableTransactionManagementConfiguration.CglibAutoProxyConfiguration matched:
      - @ConditionalOnProperty (spring.aop.proxy-target-class=true) matched (OnPropertyCondition)

   TransactionAutoConfiguration.TransactionTemplateConfiguration matched:
      - @ConditionalOnSingleCandidate (types: org.springframework.transaction.PlatformTransactionManager; SearchStrategy: all) found a primary bean from beans 'transactionManager' (OnBeanCondition)

   TransactionAutoConfiguration.TransactionTemplateConfiguration#transactionTemplate matched:
      - @ConditionalOnMissingBean (types: org.springframework.transaction.support.TransactionOperations; SearchStrategy: all) did not find any beans (OnBeanCondition)

   WebMvcAutoConfiguration matched:
      - @ConditionalOnClass found required classes 'javax.servlet.Servlet', 'org.springframework.web.servlet.DispatcherServlet', 'org.springframework.web.servlet.config.annotation.WebMvcConfigurer' (OnClassCond
ition)
      - found 'session' scope (OnWebApplicationCondition)
      - @ConditionalOnMissingBean (types: org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport; SearchStrategy: all) did not find any beans (OnBeanCondition)

   WebMvcAutoConfiguration#formContentFilter matched:
      - @ConditionalOnProperty (spring.mvc.formcontent.filter.enabled) matched (OnPropertyCondition)
      - @ConditionalOnMissingBean (types: org.springframework.web.filter.FormContentFilter; SearchStrategy: all) did not find any beans (OnBeanCondition)

   WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter#defaultViewResolver matched:
      - @ConditionalOnMissingBean (types: org.springframework.web.servlet.view.InternalResourceViewResolver; SearchStrategy: all) did not find any beans (OnBeanCondition)

   WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter#requestContextFilter matched:
      - @ConditionalOnMissingBean (types: org.springframework.web.context.request.RequestContextListener,org.springframework.web.filter.RequestContextFilter; SearchStrategy: all) did not find any beans (OnBeanC
ondition)

   WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter#viewResolver matched:
      - @ConditionalOnBean (types: org.springframework.web.servlet.ViewResolver; SearchStrategy: all) found beans 'defaultViewResolver', 'beanNameViewResolver', 'mvcViewResolver'; @ConditionalOnMissingBean (nam
es: viewResolver types: org.springframework.web.servlet.view.ContentNegotiatingViewResolver; SearchStrategy: all) did not find any beans (OnBeanCondition)

   WebSocketServletAutoConfiguration matched:
      - @ConditionalOnClass found required classes 'javax.servlet.Servlet', 'javax.websocket.server.ServerContainer' (OnClassCondition)
      - found 'session' scope (OnWebApplicationCondition)

   WebSocketServletAutoConfiguration.TomcatWebSocketConfiguration matched:
      - @ConditionalOnClass found required classes 'org.apache.catalina.startup.Tomcat', 'org.apache.tomcat.websocket.server.WsSci' (OnClassCondition)

   WebSocketServletAutoConfiguration.TomcatWebSocketConfiguration#websocketServletWebServerCustomizer matched:
      - @ConditionalOnMissingBean (names: websocketServletWebServerCustomizer; SearchStrategy: all) did not find any beans (OnBeanCondition)


Negative matches:
-----------------

   ActiveMQAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'javax.jms.ConnectionFactory' (OnClassCondition)

   AopAutoConfiguration.AspectJAutoProxyingConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.aspectj.weaver.Advice' (OnClassCondition)

   ArtemisAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'javax.jms.ConnectionFactory' (OnClassCondition)

   BatchAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.batch.core.launch.JobLauncher' (OnClassCondition)

   CacheAutoConfiguration:
      Did not match:
         - @ConditionalOnBean (types: org.springframework.cache.interceptor.CacheAspectSupport; SearchStrategy: all) did not find any beans of type org.springframework.cache.interceptor.CacheAspectSupport (OnBe
anCondition)
      Matched:
         - @ConditionalOnClass found required class 'org.springframework.cache.CacheManager' (OnClassCondition)

   CacheAutoConfiguration.CacheManagerEntityManagerFactoryDependsOnPostProcessor:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean' (OnClassCondition)
         - Ancestor org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration did not match (ConditionEvaluationReport.AncestorsMatchedCondition)

   CaffeineCacheConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.github.benmanes.caffeine.cache.Caffeine' (OnClassCondition)

   CassandraAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.datastax.oss.driver.api.core.CqlSession' (OnClassCondition)

   CassandraDataAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.datastax.oss.driver.api.core.CqlSession' (OnClassCondition)

   CassandraReactiveDataAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.datastax.oss.driver.api.core.CqlSession' (OnClassCondition)

   CassandraReactiveRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.cassandra.ReactiveSession' (OnClassCondition)

   CassandraRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.datastax.oss.driver.api.core.CqlSession' (OnClassCondition)

   ClientHttpConnectorAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.web.reactive.function.client.WebClient' (OnClassCondition)

   CodecsAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.web.reactive.function.client.WebClient' (OnClassCondition)

   CouchbaseAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.couchbase.client.java.Cluster' (OnClassCondition)

   CouchbaseCacheConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.couchbase.client.java.Cluster' (OnClassCondition)

   CouchbaseDataAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.couchbase.client.java.Bucket' (OnClassCondition)

   CouchbaseReactiveDataAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.couchbase.client.java.Cluster' (OnClassCondition)

   CouchbaseReactiveRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.couchbase.client.java.Cluster' (OnClassCondition)

   CouchbaseRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.couchbase.client.java.Bucket' (OnClassCondition)

   DataSourceAutoConfiguration.EmbeddedDatabaseConfiguration:
      Did not match:
         - EmbeddedDataSource spring.datasource.url is set (DataSourceAutoConfiguration.EmbeddedDatabaseCondition)

   DataSourceConfiguration.Dbcp2:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.apache.commons.dbcp2.BasicDataSource' (OnClassCondition)

   DataSourceConfiguration.Generic:
      Did not match:
         - @ConditionalOnProperty (spring.datasource.type) did not find property 'spring.datasource.type' (OnPropertyCondition)

   DataSourceConfiguration.Tomcat:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.apache.tomcat.jdbc.pool.DataSource' (OnClassCondition)

   DataSourceJmxConfiguration.TomcatDataSourceJmxConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.apache.tomcat.jdbc.pool.DataSourceProxy' (OnClassCondition)

   DataSourcePoolMetadataProvidersConfiguration.CommonsDbcp2PoolDataSourceMetadataProviderConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.apache.commons.dbcp2.BasicDataSource' (OnClassCondition)

   DataSourcePoolMetadataProvidersConfiguration.TomcatDataSourcePoolMetadataProviderConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.apache.tomcat.jdbc.pool.DataSource' (OnClassCondition)

   DispatcherServletAutoConfiguration.DispatcherServletConfiguration#multipartResolver:
      Did not match:
         - @ConditionalOnBean (types: org.springframework.web.multipart.MultipartResolver; SearchStrategy: all) did not find any beans of type org.springframework.web.multipart.MultipartResolver (OnBeanConditio
n)

   EhCacheCacheConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'net.sf.ehcache.Cache' (OnClassCondition)

   ElasticsearchDataAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.elasticsearch.core.ElasticsearchTemplate' (OnClassCondition)

   ElasticsearchRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.elasticsearch.client.Client' (OnClassCondition)

   ElasticsearchRestClientAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.elasticsearch.client.RestClient' (OnClassCondition)

   EmbeddedLdapAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.unboundid.ldap.listener.InMemoryDirectoryServer' (OnClassCondition)

   EmbeddedMongoAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.mongodb.MongoClientSettings' (OnClassCondition)

   EmbeddedWebServerFactoryCustomizerAutoConfiguration.JettyWebServerFactoryCustomizerConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required classes 'org.eclipse.jetty.server.Server', 'org.eclipse.jetty.util.Loader', 'org.eclipse.jetty.webapp.WebAppContext' (OnClassCondition)

   EmbeddedWebServerFactoryCustomizerAutoConfiguration.NettyWebServerFactoryCustomizerConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'reactor.netty.http.server.HttpServer' (OnClassCondition)

   EmbeddedWebServerFactoryCustomizerAutoConfiguration.UndertowWebServerFactoryCustomizerConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required classes 'io.undertow.Undertow', 'org.xnio.SslClientAuthMode' (OnClassCondition)

   ErrorWebFluxAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.web.reactive.config.WebFluxConfigurer' (OnClassCondition)

   FlywayAutoConfiguration.FlywayEntityManagerFactoryDependsOnPostProcessor:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean' (OnClassCondition)

   FlywayAutoConfiguration.FlywayMigrationInitializerEntityManagerFactoryDependsOnPostProcessor:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean' (OnClassCondition)

   FreeMarkerAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'freemarker.template.Configuration' (OnClassCondition)

   GroovyTemplateAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'groovy.text.markup.MarkupTemplateEngine' (OnClassCondition)

   GsonHttpMessageConvertersConfiguration.GsonHttpMessageConverterConfiguration:
      Did not match:
         - AnyNestedCondition 0 matched 2 did not; NestedCondition on GsonHttpMessageConvertersConfiguration.PreferGsonOrJacksonAndJsonbUnavailableCondition.JacksonJsonbUnavailable NoneNestedConditions 1 matche
d 1 did not; NestedCondition on GsonHttpMessageConvertersConfiguration.JacksonAndJsonbUnavailableCondition.JsonbPreferred @ConditionalOnProperty (spring.mvc.converters.preferred-json-mapper=jsonb) did not find
property 'spring.mvc.converters.preferred-json-mapper'; NestedCondition on GsonHttpMessageConvertersConfiguration.JacksonAndJsonbUnavailableCondition.JacksonAvailable @ConditionalOnBean (types: org.springframew
ork.http.converter.json.MappingJackson2HttpMessageConverter; SearchStrategy: all) found bean 'mappingJackson2HttpMessageConverter'; NestedCondition on GsonHttpMessageConvertersConfiguration.PreferGsonOrJacksonA
ndJsonbUnavailableCondition.GsonPreferred @ConditionalOnProperty (spring.mvc.converters.preferred-json-mapper=gson) did not find property 'spring.mvc.converters.preferred-json-mapper' (GsonHttpMessageConverters
Configuration.PreferGsonOrJacksonAndJsonbUnavailableCondition)

   H2ConsoleAutoConfiguration:
      Did not match:
         - @ConditionalOnProperty (spring.h2.console.enabled=true) did not find property 'enabled' (OnPropertyCondition)
      Matched:
         - @ConditionalOnClass found required class 'org.h2.server.web.WebServlet' (OnClassCondition)
         - found 'session' scope (OnWebApplicationCondition)

   HazelcastAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.hazelcast.core.HazelcastInstance' (OnClassCondition)

   HazelcastCacheConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.hazelcast.core.HazelcastInstance' (OnClassCondition)

   HazelcastJpaDependencyAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.hazelcast.core.HazelcastInstance' (OnClassCondition)

   HibernateJpaAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'javax.persistence.EntityManager' (OnClassCondition)

   HttpHandlerAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.web.reactive.DispatcherHandler' (OnClassCondition)

   HypermediaAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.hateoas.EntityModel' (OnClassCondition)

   InfinispanCacheConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.infinispan.spring.embedded.provider.SpringEmbeddedCacheManager' (OnClassCondition)

   InfluxDbAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.influxdb.InfluxDB' (OnClassCondition)

   IntegrationAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.integration.config.EnableIntegration' (OnClassCondition)

   JCacheCacheConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'javax.cache.Caching' (OnClassCondition)

   JacksonHttpMessageConvertersConfiguration.MappingJackson2XmlHttpMessageConverterConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.fasterxml.jackson.dataformat.xml.XmlMapper' (OnClassCondition)

   JerseyAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.glassfish.jersey.server.spring.SpringComponentProvider' (OnClassCondition)

   JmsAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'javax.jms.Message' (OnClassCondition)

   JmxAutoConfiguration:
      Did not match:
         - @ConditionalOnProperty (spring.jmx.enabled=true) did not find property 'enabled' (OnPropertyCondition)
      Matched:
         - @ConditionalOnClass found required class 'org.springframework.jmx.export.MBeanExporter' (OnClassCondition)

   JndiConnectionFactoryAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.jms.core.JmsTemplate' (OnClassCondition)

   JndiDataSourceAutoConfiguration:
      Did not match:
         - @ConditionalOnProperty (spring.datasource.jndi-name) did not find property 'jndi-name' (OnPropertyCondition)
      Matched:
         - @ConditionalOnClass found required classes 'javax.sql.DataSource', 'org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType' (OnClassCondition)

   JpaRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.jpa.repository.JpaRepository' (OnClassCondition)

   JsonbAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'javax.json.bind.Jsonb' (OnClassCondition)

   JsonbHttpMessageConvertersConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'javax.json.bind.Jsonb' (OnClassCondition)

   JtaAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'javax.transaction.Transaction' (OnClassCondition)

   KafkaAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.kafka.core.KafkaTemplate' (OnClassCondition)

   LdapAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.ldap.core.ContextSource' (OnClassCondition)

   LdapRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.ldap.repository.LdapRepository' (OnClassCondition)

   LiquibaseAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'liquibase.change.DatabaseChange' (OnClassCondition)

   MailSenderAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.mail.MailSender' (OnClassCondition)

   MailSenderValidatorAutoConfiguration:
      Did not match:
         - @ConditionalOnSingleCandidate did not find required type 'org.springframework.mail.javamail.JavaMailSenderImpl' (OnBeanCondition)

   MessageSourceAutoConfiguration:
      Did not match:
         - ResourceBundle did not find bundle with basename messages (MessageSourceAutoConfiguration.ResourceBundleCondition)

   MongoAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.mongodb.client.MongoClient' (OnClassCondition)

   MongoDataAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.mongodb.client.MongoClient' (OnClassCondition)

   MongoReactiveAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.mongodb.reactivestreams.client.MongoClient' (OnClassCondition)

   MongoReactiveDataAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.mongodb.reactivestreams.client.MongoClient' (OnClassCondition)

   MongoReactiveRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.mongodb.reactivestreams.client.MongoClient' (OnClassCondition)

   MongoRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.mongodb.client.MongoClient' (OnClassCondition)

   MustacheReactiveWebConfiguration:
      Did not match:
         - did not find reactive web application classes (OnWebApplicationCondition)

   Neo4jDataAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.neo4j.ogm.session.SessionFactory' (OnClassCondition)

   Neo4jRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.neo4j.ogm.session.Neo4jSession' (OnClassCondition)

   OAuth2ClientAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.security.config.annotation.web.configuration.EnableWebSecurity' (OnClassCondition)

   OAuth2ResourceServerAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken' (OnClassCondition)

   ProjectInfoAutoConfiguration#buildProperties:
      Did not match:
         - @ConditionalOnResource did not find resource '${spring.info.build.location:classpath:META-INF/build-info.properties}' (OnResourceCondition)

   ProjectInfoAutoConfiguration#gitProperties:
      Did not match:
         - GitResource did not find git info at classpath:git.properties (ProjectInfoAutoConfiguration.GitResourceAvailableCondition)

   QuartzAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.quartz.Scheduler' (OnClassCondition)

   R2dbcAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'io.r2dbc.spi.ConnectionFactory' (OnClassCondition)

   R2dbcDataAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.r2dbc.core.DatabaseClient' (OnClassCondition)

   R2dbcRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'io.r2dbc.spi.ConnectionFactory' (OnClassCondition)

   R2dbcTransactionManagerAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.r2dbc.connectionfactory.R2dbcTransactionManager' (OnClassCondition)

   RSocketMessagingAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'io.rsocket.RSocketFactory' (OnClassCondition)

   RSocketRequesterAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'io.rsocket.RSocketFactory' (OnClassCondition)

   RSocketSecurityAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.security.rsocket.core.SecuritySocketAcceptorInterceptor' (OnClassCondition)

   RSocketServerAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'io.rsocket.core.RSocketServer' (OnClassCondition)

   RSocketStrategiesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'io.netty.buffer.PooledByteBufAllocator' (OnClassCondition)

   RabbitAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.rabbitmq.client.Channel' (OnClassCondition)

   ReactiveElasticsearchRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient' (OnClassCondition)

   ReactiveElasticsearchRestClientAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'reactor.netty.http.client.HttpClient' (OnClassCondition)

   ReactiveOAuth2ClientAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'reactor.core.publisher.Flux' (OnClassCondition)

   ReactiveOAuth2ResourceServerAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity' (OnClassCondition)

   ReactiveSecurityAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'reactor.core.publisher.Flux' (OnClassCondition)

   ReactiveUserDetailsServiceAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.security.authentication.ReactiveAuthenticationManager' (OnClassCondition)

   ReactiveWebServerFactoryAutoConfiguration:
      Did not match:
         - @ConditionalOnWebApplication did not find reactive web application classes (OnWebApplicationCondition)

   RedisAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.redis.core.RedisOperations' (OnClassCondition)

   RedisCacheConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.redis.connection.RedisConnectionFactory' (OnClassCondition)

   RedisReactiveAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'reactor.core.publisher.Flux' (OnClassCondition)

   RedisRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.redis.repository.configuration.EnableRedisRepositories' (OnClassCondition)

   RepositoryRestMvcAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration' (OnClassCondition)

   Saml2RelyingPartyAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository' (OnClassCondition)

   SecurityAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.security.authentication.DefaultAuthenticationEventPublisher' (OnClassCondition)

   SecurityFilterAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.security.config.http.SessionCreationPolicy' (OnClassCondition)

   SendGridAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'com.sendgrid.SendGrid' (OnClassCondition)

   ServletWebServerFactoryAutoConfiguration#forwardedHeaderFilter:
      Did not match:
         - @ConditionalOnProperty (server.forward-headers-strategy=framework) did not find property 'server.forward-headers-strategy' (OnPropertyCondition)

   ServletWebServerFactoryConfiguration.EmbeddedJetty:
      Did not match:
         - @ConditionalOnClass did not find required classes 'org.eclipse.jetty.server.Server', 'org.eclipse.jetty.util.Loader', 'org.eclipse.jetty.webapp.WebAppContext' (OnClassCondition)

   ServletWebServerFactoryConfiguration.EmbeddedUndertow:
      Did not match:
         - @ConditionalOnClass did not find required classes 'io.undertow.Undertow', 'org.xnio.SslClientAuthMode' (OnClassCondition)

   SessionAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.session.Session' (OnClassCondition)

   SolrAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.apache.solr.client.solrj.impl.CloudSolrClient' (OnClassCondition)

   SolrRepositoriesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.apache.solr.client.solrj.SolrClient' (OnClassCondition)

   SpringApplicationAdminJmxAutoConfiguration:
      Did not match:
         - @ConditionalOnProperty (spring.application.admin.enabled=true) did not find property 'enabled' (OnPropertyCondition)

   ThymeleafAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.thymeleaf.spring5.SpringTemplateEngine' (OnClassCondition)

   TransactionAutoConfiguration#transactionalOperator:
      Did not match:
         - @ConditionalOnSingleCandidate (types: org.springframework.transaction.ReactiveTransactionManager; SearchStrategy: all) did not find any beans (OnBeanCondition)

   TransactionAutoConfiguration.EnableTransactionManagementConfiguration.JdkDynamicAutoProxyConfiguration:
      Did not match:
         - @ConditionalOnProperty (spring.aop.proxy-target-class=false) did not find property 'proxy-target-class' (OnPropertyCondition)

   UserDetailsServiceAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.security.authentication.AuthenticationManager' (OnClassCondition)

   ValidationAutoConfiguration:
      Did not match:
         - @ConditionalOnResource did not find resource 'classpath:META-INF/services/javax.validation.spi.ValidationProvider' (OnResourceCondition)
      Matched:
         - @ConditionalOnClass found required class 'javax.validation.executable.ExecutableValidator' (OnClassCondition)

   WebClientAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.web.reactive.function.client.WebClient' (OnClassCondition)

   WebFluxAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.web.reactive.config.WebFluxConfigurer' (OnClassCondition)

   WebMvcAutoConfiguration#hiddenHttpMethodFilter:
      Did not match:
         - @ConditionalOnProperty (spring.mvc.hiddenmethod.filter.enabled) did not find property 'enabled' (OnPropertyCondition)

   WebMvcAutoConfiguration.ResourceChainCustomizerConfiguration:
      Did not match:
         - @ConditionalOnEnabledResourceChain did not find class org.webjars.WebJarAssetLocator (OnEnabledResourceChainCondition)

   WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter#beanNameViewResolver:
      Did not match:
         - @ConditionalOnMissingBean (types: org.springframework.web.servlet.view.BeanNameViewResolver; SearchStrategy: all) found beans of type 'org.springframework.web.servlet.view.BeanNameViewResolver' beanN
ameViewResolver (OnBeanCondition)

   WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter#localeResolver:
      Did not match:
         - @ConditionalOnProperty (spring.mvc.locale) did not find property 'locale' (OnPropertyCondition)

   WebServiceTemplateAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.oxm.Marshaller' (OnClassCondition)

   WebServicesAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.ws.transport.http.MessageDispatcherServlet' (OnClassCondition)

   WebSocketMessagingAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer' (OnClassCondition)

   WebSocketReactiveAutoConfiguration:
      Did not match:
         - @ConditionalOnWebApplication did not find reactive web application classes (OnWebApplicationCondition)

   WebSocketServletAutoConfiguration.JettyWebSocketConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer' (OnClassCondition)

   WebSocketServletAutoConfiguration.UndertowWebSocketConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'io.undertow.websockets.jsr.Bootstrap' (OnClassCondition)

   XADataSourceAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'javax.transaction.TransactionManager' (OnClassCondition)


Exclusions:
-----------

    None


Unconditional classes:
----------------------

    org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration

    org.springframework.boot.autoconfigure.context.LifecycleAutoConfiguration

    org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration

    org.springframework.boot.autoconfigure.availability.ApplicationAvailabilityAutoConfiguration

    org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration



2020-10-08 11:34:32.926  INFO 9644 --- [           main] com.test.SpringMain                      : Started SpringMain in 5.118 seconds (JVM running for 6.277)
2020-10-08 11:34:32.937 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@266243ca
2020-10-08 11:34:32.938 DEBUG 9644 --- [onnection adder] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:32.938 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:32.938 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:32.938 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:32.938 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:32.939 ERROR 9644 --- [           main] com.test.SpringMain                      : ERROR Level logging visible
2020-10-08 11:34:32.939  WARN 9644 --- [           main] com.test.SpringMain                      : WARN Level logging visible
2020-10-08 11:34:32.939  INFO 9644 --- [           main] com.test.SpringMain                      : INFO Level logging visible
2020-10-08 11:34:32.939 DEBUG 9644 --- [           main] com.test.SpringMain                      : DEBUG Level logging visible
2020-10-08 11:34:32.940 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:32.940 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:33.540 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@28a5b976
2020-10-08 11:34:33.541 DEBUG 9644 --- [onnection adder] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:33.541 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:33.541 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:33.541 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:33.542 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:33.543 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:33.543 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:34.217 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@2c9a28ba
2020-10-08 11:34:34.217 DEBUG 9644 --- [onnection adder] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:34.218 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:34.218 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:34.218 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:34.219 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:34.231 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:34.231 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:34.953 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@6998b34d
2020-10-08 11:34:34.954 DEBUG 9644 --- [onnection adder] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:34.954 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:34.955 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:34.965 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:34.965 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:34.968 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:34.968 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:35.693 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@5dd0c1a7
2020-10-08 11:34:35.694 DEBUG 9644 --- [onnection adder] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:35.694 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:35.694 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:35.694 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:35.694 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:35.695 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:35.695 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:36.384 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@583bbd62
2020-10-08 11:34:36.384 DEBUG 9644 --- [onnection adder] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:36.385 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:36.385 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:36.385 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:36.385 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:36.387 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:36.387 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:37.032 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@25999127
2020-10-08 11:34:37.032 DEBUG 9644 --- [onnection adder] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:37.033 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:37.033 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:37.033 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:37.034 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:37.035 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:37.035 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:37.633 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@9b74c02
2020-10-08 11:34:37.633 DEBUG 9644 --- [onnection adder] org.postgresql.Driver                    : Connecting with URL: jdbc:postgresql://localhost:5432/myDB
2020-10-08 11:34:37.633 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         : PostgreSQL JDBC Driver 42.2.16
2020-10-08 11:34:37.634 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setDefaultFetchSize = 0
2020-10-08 11:34:37.634 DEBUG 9644 --- [onnection adder] org.postgresql.jdbc.PgConnection         :   setPrepareThreshold = 5
2020-10-08 11:34:37.634 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Trying to establish a protocol version 3 connection to localhost:5432
2020-10-08 11:34:37.636 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Receive Buffer Size is 65á536
2020-10-08 11:34:37.636 DEBUG 9644 --- [onnection adder] o.p.core.v3.ConnectionFactoryImpl        : Send Buffer Size is 64á512
2020-10-08 11:34:38.256 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@5231696a
2020-10-08 11:34:38.257 DEBUG 9644 --- [onnection adder] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - After adding stats (total=10, active=0, idle=10, waiting=0)
2020-10-08 11:34:43.400 DEBUG 9644 --- [extShutdownHook] ConfigServletWebServerApplicationContext : Closing org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@676cf4
8, started on Thu Oct 08 11:34:28 CEST 2020
2020-10-08 11:34:43.401 DEBUG 9644 --- [extShutdownHook] o.s.c.support.DefaultLifecycleProcessor  : Stopping beans in phase 2147483647
2020-10-08 11:34:43.403 DEBUG 9644 --- [extShutdownHook] o.s.c.support.DefaultLifecycleProcessor  : Bean 'webServerGracefulShutdown' completed its stop procedure
2020-10-08 11:34:43.403 DEBUG 9644 --- [extShutdownHook] o.s.c.support.DefaultLifecycleProcessor  : Stopping beans in phase 2147483646
2020-10-08 11:34:44.226 DEBUG 9644 --- [extShutdownHook] o.s.c.support.DefaultLifecycleProcessor  : Bean 'webServerStartStop' completed its stop procedure
2020-10-08 11:34:44.227  INFO 9644 --- [extShutdownHook] o.s.s.c.ThreadPoolTaskScheduler          : Shutting down ExecutorService 'taskScheduler'
2020-10-08 11:34:44.229  INFO 9644 --- [extShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2020-10-08 11:34:44.229 DEBUG 9644 --- [extShutdownHook] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Before shutdown stats (total=10, active=0, idle=10, waiting=0)
2020-10-08 11:34:44.231 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@33bb3f86: (connection evicted)
2020-10-08 11:34:44.233 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@266243ca: (connection evicted)
2020-10-08 11:34:44.235 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@28a5b976: (connection evicted)
2020-10-08 11:34:44.249 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@2c9a28ba: (connection evicted)
2020-10-08 11:34:44.250 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@6998b34d: (connection evicted)
2020-10-08 11:34:44.251 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@5dd0c1a7: (connection evicted)
2020-10-08 11:34:44.252 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@583bbd62: (connection evicted)
2020-10-08 11:34:44.253 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@25999127: (connection evicted)
2020-10-08 11:34:44.254 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@9b74c02: (connection evicted)
2020-10-08 11:34:44.255 DEBUG 9644 --- [nnection closer] com.zaxxer.hikari.pool.PoolBase          : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@5231696a: (connection evicted)
2020-10-08 11:34:44.257 DEBUG 9644 --- [extShutdownHook] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - After shutdown stats (total=0, active=0, idle=0, waiting=0)
2020-10-08 11:34:44.257  INFO 9644 --- [extShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
2020-10-08 11:34:44.258  INFO 9644 --- [extShutdownHook] o.s.s.concurrent.ThreadPoolTaskExecutor  : Shutting down ExecutorService 'applicationTaskExecutor'
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.877 s
[INFO] Finished at: 2020-10-08T11:34:44+02:00
[INFO] ------------------------------------------------------------------------